### PR TITLE
Fix mono test

### DIFF
--- a/src/L10NSharpTests/LocalizationManagerTests.cs
+++ b/src/L10NSharpTests/LocalizationManagerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
@@ -200,6 +201,10 @@ namespace L10NSharp.Tests
 		[Test]
 		public void GetUiLanguages_AzeriHasHackedNativeName()
 		{
+			// Check if the OS includes 'az' culture - Ubuntu 12.04 Precise doesn't
+			if (!CultureInfo.GetCultures(CultureTypes.NeutralCultures).Select(c => c.Name == "az").Any())
+				Assert.Ignore("Test requires the availability of the 'az' culture");
+
 			var cultures = LocalizationManager.GetUILanguages(false);
 			Assert.AreEqual("Azərbaycan dili", cultures.Where(c => c.Name == "az").Select(c => c.NativeName).FirstOrDefault());
 		}


### PR DESCRIPTION
Ubuntu Precise does not have 'az' culture. Trusty does.
This test will be ignored on Precise, but will pass correctly on Trusty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/4)
<!-- Reviewable:end -->
