### PR TITLE
Add static L10NManager.GetAvailableUILanguageTags method (BL-4393)

### DIFF
--- a/src/L10NSharp/LocalizationManager.cs
+++ b/src/L10NSharp/LocalizationManager.cs
@@ -372,6 +372,24 @@ namespace L10NSharp
 				   orderby ci.DisplayName
 				   select ci;
 		}
+
+		/// <summary>
+		/// Return the language tags for those languages that have been localized for the given program
+		/// in its localization folder.
+		/// </summary>
+		public static IEnumerable<string> GetAvailableUILanguageTags(string localizationFolder, string programName)
+		{
+			var tags = new List<string>();
+			if (!Directory.Exists(localizationFolder))
+				return tags;
+			foreach (var filepath in Directory.GetFiles(localizationFolder, programName + ".*.tmx"))
+			{
+				var filename = Path.GetFileNameWithoutExtension(filepath);
+				var tag = filename.Substring(programName.Length + 1);
+				tags.Add(tag);
+			}
+			return tags;
+		}
 		#endregion
 
 		#region Methods for showing localization dialog box

--- a/src/L10NSharpTests/LocalizationManagerTests.cs
+++ b/src/L10NSharpTests/LocalizationManagerTests.cs
@@ -481,5 +481,18 @@ namespace L10NSharp.Tests
 			return tu;
 		}
 
+		[Test]
+		public void GetAvailableUILanguageTags_FindsThreeLanguages()
+		{
+			using (var folder = new TempFolder("GetAvailableUILanguageTags_FindsThreeLanguages"))
+			{
+				SetupManager(folder, "en");
+				var tags = LocalizationManager.GetAvailableUILanguageTags(GetInstalledDirectory(folder), AppId).ToArray();
+				Assert.That(tags.Length, Is.EqualTo(3));
+				Assert.That(tags.Contains("ar"), Is.True);
+				Assert.That(tags.Contains("en"), Is.True);
+				Assert.That(tags.Contains("fr"), Is.True);
+			}
+		}
 	}
 }


### PR DESCRIPTION
This is needed by Bloom to help automate choosing the UI language at
the user's first program startup.  (and possibly later if a user
changes the system UI language)  This could be done by initializing
a LocationManager object and calling its GetUILanguages(true) method,
but that's a lot more expensive.