### PR TITLE
Add a GetString overload that takes a prioritized list of desired langs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+root = true
+
+# Defaults
+[*]
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8
+indent_size = 4
+
+[*.{cs,csproj,sln}]
+indent_style = tab
+
+[*.pug]
+indent_style = tab
+
+[*.{ts,json,js,md,jsx,css,less}]
+indent_style = space
+
+[*.tmx]
+indent_style = space
+indent_size = 2
+
+[*.sh]
+end_of_line = lf

--- a/src/L10NSharp/LocalizationManager.cs
+++ b/src/L10NSharp/LocalizationManager.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
@@ -234,7 +234,7 @@ namespace L10NSharp
 				Directory.CreateDirectory(dir);
 
 			var defaultStringFileInstalledPath = Path.Combine(_installedTmxFileFolder, GetTmxFileNameForLanguage(kDefaultLang));
-			if(!DefaultStringFileExistsAndHasContents() && File.Exists(defaultStringFileInstalledPath))
+			if (!DefaultStringFileExistsAndHasContents() && File.Exists(defaultStringFileInstalledPath))
 			{
 				File.Copy(defaultStringFileInstalledPath, DefaultStringFilePath, true);
 			}
@@ -247,7 +247,7 @@ namespace L10NSharp
 				if (header != null)
 				{
 					verElement = header.Elements("prop")
-						.FirstOrDefault(e => (string) e.Attribute("type") == kAppVersionPropTag);
+						.FirstOrDefault(e => (string)e.Attribute("type") == kAppVersionPropTag);
 				}
 
 				if (verElement != null && new Version(verElement.Value) >= new Version(AppVersion ?? "0.0.1"))
@@ -332,8 +332,8 @@ namespace L10NSharp
 
 			// first, get all installed cultures
 			var allCultures = from ci in L10NCultureInfo.GetCultures(CultureTypes.NeutralCultures)
-					where ci.TwoLetterISOLanguageName != "iv"
-					select ci;
+							  where ci.TwoLetterISOLanguageName != "iv"
+							  select ci;
 
 			// second, group by ISO 3 letter language code
 			var groups = allCultures.GroupBy(c => c.ThreeLetterISOLanguageName);
@@ -360,7 +360,7 @@ namespace L10NSharp
 					// (short of at least a major change of API).
 					return null; // to the Select; filtered out below
 				}
-			}).Where(ci =>ci != null));
+			}).Where(ci => ci != null));
 
 			if (!returnOnlyLanguagesHavingLocalizations)
 				return from ci in allLangs
@@ -452,9 +452,9 @@ namespace L10NSharp
 						return s_uiLangId;
 					// Otherwise, we want the culture.neutral version.
 #endif
-					int i = s_uiLangId.IndexOf ('-');
+					int i = s_uiLangId.IndexOf('-');
 					if (i >= 0)
-						s_uiLangId = s_uiLangId.Substring (0, i);
+						s_uiLangId = s_uiLangId.Substring(0, i);
 				}
 
 				return s_uiLangId;
@@ -532,21 +532,21 @@ namespace L10NSharp
 				HashSet<string> langIdsOfCustomizedLocales = new HashSet<string>();
 				string langId;
 				if (_customTmxFileFolder != null && Directory.Exists(_customTmxFileFolder))
-				foreach (var tmxFile in Directory.GetFiles(_customTmxFileFolder, Id + ".*.tmx"))
-				{
-					langId = GetLangIdFromTmxFileName(tmxFile);
-					if (langId != kDefaultLang) // should never happen for customized languages
+					foreach (var tmxFile in Directory.GetFiles(_customTmxFileFolder, Id + ".*.tmx"))
 					{
-						langIdsOfCustomizedLocales.Add(langId);
-						yield return tmxFile;
+						langId = GetLangIdFromTmxFileName(tmxFile);
+						if (langId != kDefaultLang) // should never happen for customized languages
+						{
+							langIdsOfCustomizedLocales.Add(langId);
+							yield return tmxFile;
+						}
 					}
-				}
 				if (_installedTmxFileFolder != null)
 				{
 					foreach (var tmxFile in Directory.GetFiles(_installedTmxFileFolder, Id + ".*.tmx"))
 					{
 						langId = GetLangIdFromTmxFileName(tmxFile);
-						if (  langId != kDefaultLang &&    //Don't return the english TMX here because we separately process it first.
+						if (langId != kDefaultLang &&    //Don't return the english TMX here because we separately process it first.
 							!langIdsOfCustomizedLocales.Contains(langId))
 							yield return tmxFile;
 					}
@@ -617,9 +617,9 @@ namespace L10NSharp
 			}
 			catch (Exception)
 			{
-				#if DEBUG
+#if DEBUG
 				throw; // if you hit this ( Index was outside the bounds of the array) try to figure out why. What is the hash (?) value for the component?
-				#endif
+#endif
 			}
 		}
 
@@ -857,9 +857,9 @@ namespace L10NSharp
 		/// a string cannot be found for the specified id and the current UI language.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public static string GetString(string id, string englishText)
+		public static string GetString(string stringId, string englishText)
 		{
-			return GetString(id, englishText, null, null, null, null);
+			return GetString(stringId, englishText, null, null, null, null);
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -868,9 +868,9 @@ namespace L10NSharp
 		/// a string cannot be found for the specified id and the current UI language.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public static string GetString(string id, string englishText, string comment)
+		public static string GetString(string stringId, string englishText, string comment)
 		{
-			return GetString(id, englishText, comment, null, null, null);
+			return GetString(stringId, englishText, comment, null, null, null);
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -879,9 +879,9 @@ namespace L10NSharp
 		/// a string cannot be found for the specified id and the current UI language.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public static string GetString(string id, string englishText, string comment, IComponent component)
+		public static string GetString(string stringId, string englishText, string comment, IComponent component)
 		{
-			return GetString(id, englishText, comment, null, null, component);
+			return GetString(stringId, englishText, comment, null, null, component);
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -890,25 +890,55 @@ namespace L10NSharp
 		/// a string cannot be found for the specified id and the current UI language.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public static string GetString(string id, string englishText, string comment, string englishToolTipText,
+		public static string GetString(string stringId, string englishText, string comment, string englishToolTipText,
 			string englishShortcutKey, IComponent component)
 		{
 			if (component != null)
 			{
 				var lm = GetLocalizationManagerForComponent(component) ??
-					GetLocalizationManagerForString(id);
+					GetLocalizationManagerForString(stringId);
 
 				if (lm != null)
 				{
-					lm.RegisterComponentForLocalizing(component, id, englishText,
+					lm.RegisterComponentForLocalizing(component, stringId, englishText,
 						englishToolTipText, englishShortcutKey, comment);
 
-					return lm.GetLocalizedString(id, englishText);
+					return lm.GetLocalizedString(stringId, englishText);
 				}
 			}
 
-			return GetStringFromAnyLocalizationManager(id) ??
+			return GetStringFromAnyLocalizationManager(stringId) ??
 				StripOffLocalizationInfoFromText(englishText);
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Gets a string for the specified string id, in the specified language, or the
+		/// englishText if that wasn't found. Prefers the englishText passed here to one that
+		/// we might have got out of a tmx, as is the non-obvious-but-ultimately-correct
+		/// policy for this library.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		public static string GetString(string stringId, string englishText, string comment, IEnumerable<string> preferredLanguageIds, out string languageIdUsed)
+		{
+			if (preferredLanguageIds.Count() == 0)
+				throw new ArgumentException("preferredLanguageIds was empty");
+
+			if (string.IsNullOrEmpty(englishText))
+				throw new ArgumentException("englishText may not be empty (because common... that can't be what you meant to do...");
+
+			var r = GetStringFromAnyLocalizationManager(stringId, preferredLanguageIds, out languageIdUsed);
+
+			//even if found in English tmx, we prefer to use the version that came from the code
+			if (languageIdUsed == "en" || string.IsNullOrEmpty(r))
+			{
+				languageIdUsed = "en";
+				return StripOffLocalizationInfoFromText(englishText);
+			}
+			else
+			{
+				return r;
+			}
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -934,7 +964,7 @@ namespace L10NSharp
 		/// ------------------------------------------------------------------------------------
 		public static string GetDynamicString(string appId, string id, string englishText, string comment)
 		{
-			return GetDynamicStringOrEnglish(appId,id,englishText,comment, UILanguageId);
+			return GetDynamicStringOrEnglish(appId, id, englishText, comment, UILanguageId);
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -954,7 +984,7 @@ namespace L10NSharp
 			//this happens in unit test environments or apps that
 			//have imported a library that is L10N'ized, but the app
 			//itself isn't initializing L10N yet.
-			if(LoadedManagers.Count==0)
+			if (LoadedManagers.Count == 0)
 			{
 				return id;
 			}
@@ -972,7 +1002,7 @@ namespace L10NSharp
 			// recover the TMX version, we will retrieve that if no default is provided.
 			// Otherwise, let's look up this string, maybe it has been translated and put into a TMX
 			if (langId != "en" || englishText == null)
-				{
+			{
 				var text = lm.GetStringFromStringCache(langId, id);
 				if (text != null)
 					return text;
@@ -1013,7 +1043,7 @@ namespace L10NSharp
 		/// ------------------------------------------------------------------------------------
 		public static bool GetIsStringAvailableForLangId(string id, string langId)
 		{
-			return LoadedManagers.Values.Select(lm => lm.StringCache.GetValueForLangAndId(langId, id,false))
+			return LoadedManagers.Values.Select(lm => lm.StringCache.GetValueForExactLangAndId(langId, id, false))
 				.FirstOrDefault(txt => txt != null) != null;
 		}
 
@@ -1029,15 +1059,35 @@ namespace L10NSharp
 		}
 
 		/// ------------------------------------------------------------------------------------
-		private static string GetStringFromAnyLocalizationManager(string id)
+		private static string GetStringFromAnyLocalizationManager(string stringId)
 		{
+			// Note: this is odd semantics to me (JH); looks to be part of the rule that we prefer the 
+			// English from the program source to the English from the tmx.
+
 			// This will enforce that the text to localize is just returned to the caller
 			// when the default language id is the same as the current UI langauge id.
 			if (UILanguageId == kDefaultLang)
 				return null;
 
-			return LoadedManagers.Values.Select(lm => lm.StringCache.GetString(UILanguageId, id))
-				.FirstOrDefault(text => text != null);
+			string languageIdUsed;
+			return GetStringFromAnyLocalizationManager(stringId, new[] { UILanguageId }, out languageIdUsed);
+		}
+
+		/// ------------------------------------------------------------------------------------
+		private static string GetStringFromAnyLocalizationManager(string stringId, IEnumerable<string> preferredLanguageIds, out string languageIdUsed)
+		{
+			foreach (var langId in preferredLanguageIds)
+			{
+				var bestAnswer = LoadedManagers.Values.Select(lm => lm.StringCache.GetValueForExactLangAndId(langId, stringId, true))
+					.FirstOrDefault(text => text != null);
+				if (!string.IsNullOrEmpty(bestAnswer))
+				{
+					languageIdUsed = langId;
+					return bestAnswer;
+				}
+			}
+			languageIdUsed = null;
+			return null;
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -1144,7 +1194,7 @@ namespace L10NSharp
 			for (int i = 0; i < controls.Length; i++)
 			{
 				var toolTipText = GetTooltipFromStringCache(UILanguageId, controls[i].Value);
-				if(!string.IsNullOrEmpty(toolTipText)) //JH: hoping to speed this up a bit
+				if (!string.IsNullOrEmpty(toolTipText)) //JH: hoping to speed this up a bit
 					ApplyLocalizedToolTipToControl((Control)controls[i].Key, toolTipText);
 			}
 		}
@@ -1387,7 +1437,7 @@ namespace L10NSharp
 				tsddi = tsddi.OwnerItem as ToolStripDropDownItem;
 			}
 
-			LocalizeItemDlg.ShowDialog(this, (IComponent) sender, false);
+			LocalizeItemDlg.ShowDialog(this, (IComponent)sender, false);
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/src/L10NSharp/LocalizedStringCache.cs
+++ b/src/L10NSharp/LocalizedStringCache.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.IO;
@@ -354,9 +354,9 @@ namespace L10NSharp
 		/// ------------------------------------------------------------------------------------
 		internal bool DoTranslationsExist(string langId, string id)
 		{
-			var text = GetValueForLangAndId(langId, id, false);
-			var toolTip = GetValueForLangAndId(langId, id + kToolTipSuffix, false);
-			var shortcutKeys = GetValueForLangAndId(langId, id + kShortcutSuffix, false);
+			var text = GetValueForExactLangAndId(langId, id, false);
+			var toolTip = GetValueForExactLangAndId(langId, id + kToolTipSuffix, false);
+			var shortcutKeys = GetValueForExactLangAndId(langId, id + kShortcutSuffix, false);
 
 			return (!String.IsNullOrEmpty(text) || !String.IsNullOrEmpty(toolTip) ||
 				!String.IsNullOrEmpty(shortcutKeys));
@@ -382,7 +382,7 @@ namespace L10NSharp
 		/// ------------------------------------------------------------------------------------
 		internal string GetString(string langId, string id, bool formatForDisplay)
 		{
-			return GetValueForLangAndId(langId, id, formatForDisplay);
+			return GetValueForExactLangAndId(langId, id, formatForDisplay);
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -404,7 +404,7 @@ namespace L10NSharp
 		/// ------------------------------------------------------------------------------------
 		internal string GetToolTipText(string langId, string id, bool formatForDisplay)
 		{
-			return GetValueForLangAndId(langId, id + kToolTipSuffix, formatForDisplay);
+			return GetValueForExactLangAndId(langId, id + kToolTipSuffix, formatForDisplay);
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -425,7 +425,7 @@ namespace L10NSharp
 		/// ------------------------------------------------------------------------------------
 		internal string GetShortcutKeysText(string langId, string id)
 		{
-			return GetValueForLangAndId(langId, id + kShortcutSuffix, false);
+			return GetValueForExactLangAndId(langId, id + kShortcutSuffix, false);
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -437,18 +437,18 @@ namespace L10NSharp
 		/// ------------------------------------------------------------------------------------
 		private string GetValueForLangAndIdWithFallback(string langId, string id)
 		{
-			var value = GetValueForLangAndId(langId, id, true);
+			var value = GetValueForExactLangAndId(langId, id, true);
 			if (value != null)
 				return value;
 
 			foreach (var fallbackLangId in LocalizationManager.FallbackLanguageIds)
 			{
-				value = GetValueForLangAndId(fallbackLangId, id, true);
+				value = GetValueForExactLangAndId(fallbackLangId, id, true);
 				if (value != null)
 					return value;
 			}
 
-			return GetValueForLangAndId(LocalizationManager.kDefaultLang, id, true);
+			return GetValueForExactLangAndId(LocalizationManager.kDefaultLang, id, true);
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -458,7 +458,7 @@ namespace L10NSharp
 		/// nicely at runtime.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		internal string GetValueForLangAndId(string langId, string id, bool formatForDisplay)
+		internal string GetValueForExactLangAndId(string langId, string id, bool formatForDisplay)
 		{
 			var tu = TmxDocument.GetTransUnitForId(id);
 			if (tu == null)

--- a/src/L10NSharpTests/LocalizationManagerTests.cs
+++ b/src/L10NSharpTests/LocalizationManagerTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -188,6 +188,27 @@ namespace L10NSharp.Tests
 			{
 				SetupManager(folder, "en");
 				Assert.That(LocalizationManager.GetDynamicString(AppId, "blahId", null), Is.EqualTo("blah"), "With no default supplied, should find saved English");
+			}
+		}
+
+		//cases where we expect to get back the english in the code
+		[TestCase("en", new []{"en"}, "blahInEnglishCode", "en")]
+		[TestCase("fr", new[] { "en", "fr" }, "blahInEnglishCode", "en")]
+		[TestCase("aa", new[] { "ar", "en" }, "blahInEnglishCode", "en")] // our arabic doesn't have a translation of 'blah', so fall to the code's English
+		[TestCase("bb", new[] { "zz", "en", "fr" }, "blahInEnglishCode", "en")]
+		//cases where we expect to get back the French
+		[TestCase("cc", new[] { "fr" }, "blahInFrench", "fr")]
+		[TestCase("dd", new[] { "fr", "en" }, "blahInFrench", "fr")]
+		[TestCase("ee", new[] { "ar", "fr", "en" }, "blahInFrench", "fr")] // our arabic doesn't have a translation of 'blah', so fall to French
+		public void GetString_OverloadThatTakesListOfLanguages_Works(string uiLanguageIdShouldBeIrrelevant, IEnumerable<string> preferredLangIds,  string expectedResult, string expectedLanguage)
+		{
+			using(var folder = new TempFolder("GetString"))
+			{
+				SetupManager(folder, uiLanguageIdShouldBeIrrelevant);
+				string languageFound;
+				var result = LocalizationManager.GetString("blahId", "blahInEnglishCode", "comment", preferredLangIds, out languageFound);
+				Assert.AreEqual(expectedResult, result);
+				Assert.AreEqual(expectedLanguage, languageFound);
 			}
 		}
 


### PR DESCRIPTION
This allows getting a string to put in a document in a language that is not the UI language. This was previously possible for "dynamic" strings, but this does it for strings found in code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/10)
<!-- Reviewable:end -->
