### PR TITLE
Copy the trans-unit id string to a note to make it visible

### DIFF
--- a/src/L10NSharp/LocalizedStringCache.cs
+++ b/src/L10NSharp/LocalizedStringCache.cs
@@ -459,16 +459,15 @@ namespace L10NSharp
 		/// Gets the comment for the specified id.
 		/// </summary>
 		/// <remarks>
-		/// The xliff standard allows multiple notes in a trans-unit element.  However, we use
-		/// only one note, treating it as a comment on how to translate the source string.
-		/// (There are lots of other complexities in the xliff standard that we don't represent
-		/// well or at all.)
+		/// The xliff standard allows multiple notes in a trans-unit element.  We use one to
+		/// represent the id string (prefacing it with "ID: ").  Any other note is liable to be
+		/// considered the "comment" if it exists.
 		/// </remarks>
 		/// ------------------------------------------------------------------------------------
 		internal string GetComment(string id)
 		{
 			TransUnit tu = DefaultXliffDocument.GetTransUnitForId(id);
-			return (tu == null || tu.Notes.Count == 0 ? null : tu.Notes[0].Text);
+			return (tu == null ? null : tu.GetComment());
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/src/L10NSharp/TransUnitUpdater.cs
+++ b/src/L10NSharp/TransUnitUpdater.cs
@@ -135,11 +135,12 @@ namespace L10NSharp
 				return;
 			if (tu.Notes.Count == 0 && string.IsNullOrEmpty(locInfo.Comment))
 				return;		// empty comment and already no comment in TransUnit
-			if ((tu.Notes.Count > 0) && (tu.Notes[0].Text == locInfo.Comment))
+			if (tu.NotesContain(locInfo.Comment))
 				return;		// exactly the same comment already exists in TransUnit
 
 			_updated = true;
 			tu.Notes.Clear();
+			tu.AddNote("ID: " + tu.Id);
 			if (!string.IsNullOrEmpty(locInfo.Comment))
 				tu.AddNote(locInfo.Comment);
 		}
@@ -199,6 +200,7 @@ namespace L10NSharp
 					if (tuvSrc != null && !String.IsNullOrEmpty(tuvSrc.Value))
 						tuTarget.AddOrReplaceVariant(_defaultLang, tuvSrc.Value);
 				}
+				tuTarget.AddNote("ID: " + tuId);
 			}
 			tuTarget.AddOrReplaceVariant(locInfo.LangId, newValue);
 			xliffTarget.File.Body.TranslationsById[tuId] = newValue;

--- a/src/L10NSharp/XLiffUtils/TransUnit.cs
+++ b/src/L10NSharp/XLiffUtils/TransUnit.cs
@@ -31,7 +31,6 @@ namespace L10NSharp.XLiffUtils
 		{
 			Source = new TransUnitVariant();
 			Target = null;
-			Notes = new List<XLiffNote>();
 		}
 
 		#region Properties
@@ -70,7 +69,11 @@ namespace L10NSharp.XLiffUtils
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[XmlElement("note")]
-		public List<XLiffNote> Notes { get; set; }
+		public List<XLiffNote> Notes
+		{
+			get { return _notes; }
+			set { _notes = value; }
+		}
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>

--- a/src/L10NSharp/XLiffUtils/XLiffBaseWithNotesAndProps.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffBaseWithNotesAndProps.cs
@@ -124,6 +124,34 @@ namespace L10NSharp.XLiffUtils
 		{
 			return _props.Where(p => p.Type == type).Select(p => p.Value).FirstOrDefault();
 		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Check whether the give comment already exists as a note.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		public bool NotesContain(string comment)
+		{
+			for (int i = 0; i < _notes.Count; ++i)
+			{
+				if (_notes[i].Text == comment)
+					return true;
+			}
+			return false;
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Return the "comment" string if it exists in the notes.  We use one to represent the
+		/// id string (prefacing it with "ID: ").  Any other note is liable to be considered the
+		/// "comment" if it exists.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		public string GetComment()
+		{
+			var commentNote = _notes.FirstOrDefault(n => !string.IsNullOrEmpty(n.Text) && !n.Text.StartsWith("ID: "));
+			return commentNote == null ? null : commentNote.Text;
+		}
 	}
 
 	#endregion

--- a/src/xslt/l10nSharpTmxToXliff1-2.xsl
+++ b/src/xslt/l10nSharpTmxToXliff1-2.xsl
@@ -60,6 +60,7 @@
 				<xsl:attribute name="sil:dynamic"><xsl:value-of select="prop[@type='x-dynamic']"/></xsl:attribute>
 			</xsl:if>
 			<xsl:apply-templates select="tuv"/>
+			<xsl:element name="note">ID: <xsl:value-of select="@tuid"/></xsl:element>
 			<xsl:apply-templates select="note"/> <!-- note must follow the source and target elements in xliff. -->
 		</xsl:element>
 	</xsl:template>


### PR DESCRIPTION
Our naming convention usually describes where the string is found in
the user interface, which may be helpful for translators.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/18)
<!-- Reviewable:end -->
