### PR TITLE
Check inputs for GetValueForExactLangAndId method

### DIFF
--- a/src/L10NSharp/LocalizedStringCache.cs
+++ b/src/L10NSharp/LocalizedStringCache.cs
@@ -433,6 +433,8 @@ namespace L10NSharp
 		/// ------------------------------------------------------------------------------------
 		internal string GetValueForExactLangAndId(string langId, string id, bool formatForDisplay)
 		{
+			if (String.IsNullOrEmpty(langId) || String.IsNullOrEmpty(id))
+				return null;
 			XLiffDocument xliff;
 			if (!XliffDocuments.TryGetValue(langId, out xliff))
 				return null;


### PR DESCRIPTION
This fixes a failing test in Bloom.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/19)
<!-- Reviewable:end -->
