### PR TITLE
Fix the DefaultInstalledStringFilePath property to handle folders

### DIFF
--- a/src/L10NSharp/LocalizationManager.cs
+++ b/src/L10NSharp/LocalizationManager.cs
@@ -516,7 +516,7 @@ namespace L10NSharp
 
 		internal string DefaultInstalledStringFilePath
 		{
-			get { return Path.Combine(_installedXliffFileFolder, Id + "." + kDefaultLang + kFileExtension); }
+			get { return Path.Combine(_installedXliffFileFolder, GetXliffFileNameForLanguage(Id, kDefaultLang)); }
 		}
 
 		/// ------------------------------------------------------------------------------------


### PR DESCRIPTION
I missed this in the big PR a few days ago.  It shows up with dynamic strings not being found from javascript when running Bloom.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/20)
<!-- Reviewable:end -->
