### PR TITLE
Changed logic of GetDynamicStringOrEnglish in when no LMs are loaded so that it returns the English string.

### DIFF
--- a/src/L10NSharp/LocalizationManager.cs
+++ b/src/L10NSharp/LocalizationManager.cs
@@ -986,7 +986,7 @@ namespace L10NSharp
 			//itself isn't initializing L10N yet.
 			if (LoadedManagers.Count == 0)
 			{
-				return id;
+				return langId == "en" ? englishText ?? id : id;
 			}
 			LocalizationManager lm;
 			if (!LoadedManagers.TryGetValue(appId, out lm))
@@ -997,7 +997,6 @@ namespace L10NSharp
 			}
 
 			// If they asked for English, we are going to use the supplied englishText, regardless of what may be in
-			// some TMX, following the rule that the current c# code always wins.
 			// some TMX, following the rule that the current c# code always wins. In case we really need to
 			// recover the TMX version, we will retrieve that if no default is provided.
 			// Otherwise, let's look up this string, maybe it has been translated and put into a TMX

--- a/src/L10NSharpTests/LocalizationManagerTests.cs
+++ b/src/L10NSharpTests/LocalizationManagerTests.cs
@@ -20,6 +20,12 @@ namespace L10NSharp.Tests
 		private const string HigherVersion = "2.0.0";
 		private const string LowerVersion = "0.0.1";
 
+		[TearDown]
+		public void TearDown()
+		{
+			LocalizationManager.LoadedManagers.Clear();
+		}
+
 		/// <summary>
 		/// If there is no GeneratedDefault TMX file, but the file we need has been installed, copy the installed version to circumvent
 		/// a crash trying to generate this TMX file on Linux.
@@ -516,6 +522,40 @@ namespace L10NSharp.Tests
 				Assert.That(tags.Contains("en"), Is.True);
 				Assert.That(tags.Contains("fr"), Is.True);
 			}
+		}
+	}
+
+	[TestFixture]
+	public class LocalizationManagerTests_NoManagersLoaded
+	{
+		[TestFixtureSetUp]
+		public void TearDown()
+		{
+			LocalizationManager.LoadedManagers.Clear();
+		}
+
+		/// <summary>
+		/// According to a comment in GetDynamicStringOrEnglish, in unit test environments,
+		/// it's possible for no LM to be loaded, but according to the description of this
+		/// method, there is a "Special case" for English whereby the English string should
+		/// ALWAYS be returned. This test covers the intersection of those two special cases.
+		/// </summary>
+		[Test]
+		public void GetDynamicString_NoManagerLoaded_EnglishNotNull_ReturnsEnglishString()
+		{
+			Assert.AreEqual("data", LocalizationManager.GetDynamicString("Glom", "prefix.data", "data"));
+		}
+
+		[Test]
+		public void GetDynamicString_NoManagerLoaded_EnglishNull_ReturnsId()
+		{
+			Assert.AreEqual("prefix.data", LocalizationManager.GetDynamicString("Glom", "prefix.data", null));
+		}
+
+		[Test]
+		public void GetDynamicStringOrEnglish_NoManagerLoaded_NonEnglish_ReturnsId()
+		{
+			Assert.AreEqual("prefix.data", LocalizationManager.GetDynamicStringOrEnglish("Glom", "prefix.data", "data", "no comment", "es"));
 		}
 	}
 }


### PR DESCRIPTION
Previous behavior in this edge case was to return the id, which seems to violate the advertised behavior of the method and does not seem logical. This presumably only affects the behavior when running unit tests, but there's a chance it could also affect an app during startup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/23)
<!-- Reviewable:end -->
