### PR TITLE
Handle languages the system doesn't know about (BL-5260)

### DIFF
--- a/src/L10NSharp/L10NCultureInfo.cs
+++ b/src/L10NSharp/L10NCultureInfo.cs
@@ -5,54 +5,207 @@ using System.Linq;
 namespace L10NSharp
 {
 	/// <summary>
-	/// This class exists only to override Microsoft's NativeName for the Azeri neutral culture.
-	/// According to Ken Keyes the NativeName on the 'az-Latn' culture is correct, while the
-	/// NativeName on the 'az' culture is incorrect. So we do a swifty swap.
+	/// This class exists only to overcome the way CultureInfo is implemented to handle
+	/// only those cultures known to the authors of the .Net or Mono runtime.  On Linux,
+	/// trying to create a CultureInfo for an unknown culture throws an exception.  On
+	/// Windows for .Net 4.6, an empty object is created that cannot be modified.  This
+	/// class tries to create a CultureInfo object, and uses its values (for the most
+	/// part) if successful.  If it fails, well, there are a few languages we know
+	/// about that have been used for localization that we can handle in addition.
 	/// </summary>
-	public class L10NCultureInfo: CultureInfo
+	/// <remarks>
+	/// L10NCultureInfo objects will not provide any useful information for languages
+	/// that are not known to Windows .Net or to Mono (typically those without 2-letter
+	/// codes) and for which this class does not have any embedded information.
+	/// Therefore, this class should only be used for situations where we know only
+	/// a limited set of languages will occur, such as Bloom's UI languages.
+	/// It should not be used where the name passed in will be an arbitrary vernacular
+	/// language code.  (It won't crash, but it won't provide any information.)
+	/// </remarks>
+	public class L10NCultureInfo
 	{
-		private string _nativeName = null;
-
 		public L10NCultureInfo(string name)
-			:base(name)
 		{
-			// The Windows .Net runtime returns 'Azərbaycan dili (Azərbaycan)' for az-Latn, and
-			// something totally different for az.
-			// The Mono runtime returns "azərbaycan" for both az and az-Latn.
-			// So we just set this to what we "know" is the right value for az.
-			if (name == "az")
-				_nativeName = "Azərbaycan dili";
-		}
-
-		public override string NativeName
-		{
-			get
+			try
 			{
-				return _nativeName ?? base.NativeName;
+				RawCultureInfo = CultureInfo.GetCultureInfo(name);
+			}
+			catch (CultureNotFoundException ex)
+			{
+				RawCultureInfo = null;
+			}
+			if (RawCultureInfo == null || RawCultureInfo.EnglishName.StartsWith("Unknown Language"))
+			{
+				Name = name;
+				IsNeutralCulture = !Name.Contains("-");
+				if (IsNeutralCulture)
+				{
+					IetfLanguageTag = name;
+				}
+				else
+				{
+					var idx = name.IndexOf("-");
+					IetfLanguageTag = name.Substring(0, idx);
+				}
+				// CultureInfo returns 3-letter tags when a 2-letter tag doesn't exist.
+				// If it's a minor enough language to be unknown to .Net or Mono, it's
+				// not worth trying to find a 2-letter tag that usually wouldn't exist.
+				TwoLetterISOLanguageName = IetfLanguageTag;
+				ThreeLetterISOLanguageName = IetfLanguageTag;
+				switch (name)
+				{
+				case "pbu":
+					EnglishName = "Northern Pashto";
+					DisplayName = "Northern Pashto";
+					NativeName = "پښتو";
+					NumberFormat = CultureInfo.GetCultureInfo("ar").NumberFormat;
+					break;
+				case "prs":
+					EnglishName = "Dari";
+					DisplayName = "Dari";
+					NativeName = "دری";
+					NumberFormat = CultureInfo.GetCultureInfo("ar").NumberFormat;
+					break;
+				case "tpi":
+					EnglishName = "New Guinea Pidgin English";
+					DisplayName = "Tok Pisin";
+					NativeName = "Tok Pisin";
+					NumberFormat = CultureInfo.GetCultureInfo("en").NumberFormat;
+					break;
+				default:
+					EnglishName = string.Format("Unknown Language ({0})", name);
+					DisplayName = EnglishName;
+					NativeName = EnglishName;
+					NumberFormat = CultureInfo.InvariantCulture.NumberFormat;
+					break;
+				}
+			}
+			else
+			{
+				// The Windows .Net runtime returns 'Azərbaycan dili (Azərbaycan)' for az-Latn, and
+				// something totally different for az.
+				// The Mono runtime returns "azərbaycan" for both az and az-Latn.
+				// So we just set this to what we "know" is the right value for az.
+				if (name == "az")
+					NativeName = "Azərbaycan dili";
+				// The Windows .Net runtime returns 'Indonesia' for id.  It should be 'Bahasa Indonesia'.
+				else if (name == "id")
+					NativeName = "Bahasa Indonesia";
+				else
+					NativeName = RawCultureInfo.NativeName;
+				EnglishName = RawCultureInfo.EnglishName;
+				DisplayName = RawCultureInfo.DisplayName;
+				IsNeutralCulture = RawCultureInfo.IsNeutralCulture;
+				NumberFormat = RawCultureInfo.NumberFormat;
+				Name = RawCultureInfo.Name;
+				TwoLetterISOLanguageName = RawCultureInfo.TwoLetterISOLanguageName;
+				ThreeLetterISOLanguageName = RawCultureInfo.ThreeLetterISOLanguageName;
+				IetfLanguageTag = RawCultureInfo.IetfLanguageTag;
 			}
 		}
+
+		/// <summary>
+		/// Provide access to the underlying CultureInfo object if it exists.
+		/// </summary>
+		public CultureInfo RawCultureInfo { get; private set; }
+
+		// The following properties mimic those provided by CultureInfo.
+
+		public string NativeName { get; private set; }
+
+		public string DisplayName { get; private set; }
+
+		public string EnglishName { get; private set; }
+
+		public bool IsNeutralCulture { get; private set; }
+
+		public string Name { get; private set; }
+
+		public string TwoLetterISOLanguageName { get; private set; }
+
+		public string ThreeLetterISOLanguageName { get; private set; }
+
+		public string IetfLanguageTag { get; private set; }
+
+		public NumberFormatInfo NumberFormat { get; set; }
+
+		public static L10NCultureInfo CurrentCulture { get; internal set; }
 
 		/// <summary>
 		/// Gets the list of supported cultures in the form of L10NCultureInfo objects.
 		/// There is some danger in calling this repeatedly in that it creates new objects,
 		/// whereas the CultureInfo version appears to return cached objects.
 		/// </summary>
-		/// <param name="types"></param>
-		/// <returns></returns>
-		public new static IEnumerable<L10NCultureInfo> GetCultures(CultureTypes types)
+		public static IEnumerable<L10NCultureInfo> GetCultures(CultureTypes types)
 		{
-			return CultureInfo.GetCultures(types).Select(culture => new L10NCultureInfo(culture.Name));
+			var list = CultureInfo.GetCultures(types).Select(culture => new L10NCultureInfo(culture.Name)).ToList();
+			if ((types & CultureTypes.NeutralCultures) == CultureTypes.NeutralCultures)
+			{
+				bool havePbu = false;
+				bool havePrs = false;
+				bool haveTpi = false;
+				foreach (var ci in list)
+				{
+					if (ci.Name == "pbu")
+						havePbu = true;
+					else if (ci.Name == "prs")
+						havePrs = true;
+					else if (ci.Name == "tpi")
+						haveTpi = true;
+				}
+				if (!havePbu)
+					list.Add(GetCultureInfo("pbu"));
+				if (!havePrs)
+					list.Add(GetCultureInfo("prs"));
+				if (!haveTpi)
+					list.Add(GetCultureInfo("tpi"));
+			}
+			return list;
 		}
 
 		/// <summary>
 		/// Retrieves a new instance of a culture by using the specified culture name.
 		/// The CultureInfo version of this method returns a cached read-only instance.
 		/// </summary>
-		/// <param name="culture"></param>
-		/// <returns></returns>
-		public new static L10NCultureInfo GetCultureInfo(string culture)
+		public static L10NCultureInfo GetCultureInfo(string culture)
 		{
 			return new L10NCultureInfo(culture);
+		}
+
+		public override bool Equals(object obj)
+		{
+			var that = obj as L10NCultureInfo;
+			if (ReferenceEquals(that, null))
+				return false;
+			return (that.Name == this.Name) &&
+				(that.EnglishName == this.EnglishName);
+		}
+
+		public override int GetHashCode()
+		{
+			return Name.GetHashCode() + EnglishName.GetHashCode();
+		}
+
+		public override string ToString()
+		{
+			return string.Format("[L10NCultureInfo: Name={0}, EnglishName={1}]", Name, EnglishName);
+		}
+
+		public static bool operator ==(L10NCultureInfo ci1, L10NCultureInfo ci2)
+		{
+			if (ReferenceEquals(ci1, ci2))
+				return true;
+			if (ReferenceEquals(ci1, null))
+				return false;
+			if (ReferenceEquals(ci2, null))
+				return false;
+			return ci1.Equals(ci2);
+		}
+
+		// this is second one '!='
+		public static bool operator !=(L10NCultureInfo ci1, L10NCultureInfo ci2)
+		{
+			return !(ci1 == ci2);
 		}
 	}
 }

--- a/src/L10NSharp/LocalizationManager.cs
+++ b/src/L10NSharp/LocalizationManager.cs
@@ -111,7 +111,7 @@ namespace L10NSharp
 
 			if (string.IsNullOrEmpty(desiredUiLangId))
 			{
-				desiredUiLangId = L10NCultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
+				desiredUiLangId = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
 			}
 
 			var ci = L10NCultureInfo.GetCultureInfo(desiredUiLangId);
@@ -325,9 +325,12 @@ namespace L10NSharp
 		{
 			if (UILanguageId == langId || string.IsNullOrEmpty(langId))
 				return;
-
 			var ci = L10NCultureInfo.GetCultureInfo(langId);
-			Thread.CurrentThread.CurrentUICulture = ci;
+			if (ci.RawCultureInfo != null)
+				Thread.CurrentThread.CurrentUICulture = ci.RawCultureInfo;
+			else
+				Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+			L10NCultureInfo.CurrentCulture = ci;
 			s_uiLangId = langId;
 
 			if (reapplyLocalizationsToAllObjectsInAllManagers)
@@ -366,7 +369,7 @@ namespace L10NSharp
 		/// then all languages found are returned.
 		/// </param>
 		/// <returns>IEnumerable of L10NCultureInfo declared as IEnumerable of CultureInfo</returns>
-		public static IEnumerable<CultureInfo> GetUILanguages(bool returnOnlyLanguagesHavingLocalizations)
+		public static IEnumerable<L10NCultureInfo> GetUILanguages(bool returnOnlyLanguagesHavingLocalizations)
 		{
 			// BL-922, filter out duplicate languages. It may be surprising that we get more than one
 			// neutral culture for a given language; however, some languages are written in more than one
@@ -483,7 +486,7 @@ namespace L10NSharp
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Gets or sets the current UI language Id (i.e. the target language).
+		/// Gets the current UI language Id (i.e. the target language).
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		public static string UILanguageId

--- a/src/L10NSharpTests/L10NCultureInfoTests.cs
+++ b/src/L10NSharpTests/L10NCultureInfoTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Windows.Forms;
+using System.Xml.Linq;
+using L10NSharp.XLiffUtils;
+using L10NSharp.UI;
+using NUnit.Framework;
+
+namespace L10NSharp.Tests
+{
+	[TestFixture]
+	public class L10NCultureInfoTests
+	{
+		[Test]
+		public void L10NCultureInfo_TestEn()
+		{
+			var enci = L10NCultureInfo.GetCultureInfo("en");
+			Assert.AreEqual("English", enci.EnglishName);
+			Assert.IsNotNull(enci.RawCultureInfo);
+		}
+
+		[Test]
+		public void L10NCultureInfo_TestPbu()
+		{
+			var pbuci = L10NCultureInfo.GetCultureInfo("pbu");
+			Assert.AreEqual("Northern Pashto", pbuci.EnglishName);
+			Assert.IsNull(pbuci.RawCultureInfo);
+		}
+
+		[Test]
+		public void L10NCultureInfo_TestList()
+		{
+			var list = L10NCultureInfo.GetCultures(CultureTypes.AllCultures).ToList();
+			Assert.IsTrue(list.Contains(L10NCultureInfo.GetCultureInfo("en")));
+			Assert.IsTrue(list.Contains(L10NCultureInfo.GetCultureInfo("pbu")));
+			Assert.IsTrue(list.Contains(L10NCultureInfo.GetCultureInfo("prs")));
+		}
+	}
+}

--- a/src/L10NSharpTests/L10NSharpTests.csproj
+++ b/src/L10NSharpTests/L10NSharpTests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="ILocalizableComponentTests.cs" />
     <Compile Include="MockLocalizableComponent.cs" />
     <Compile Include="LocalizationManagerTests.cs" />
+    <Compile Include="L10NCultureInfoTests.cs" />
     <Compile Include="SchemaValidationTests.cs" />
     <Compile Include="TempFile.cs" />
     <Compile Include="UtilsTests.cs" />

--- a/src/L10NSharpTests/LocalizationManagerTests.cs
+++ b/src/L10NSharpTests/LocalizationManagerTests.cs
@@ -240,7 +240,7 @@ namespace L10NSharp.Tests
 			using (var folder = new TempFolder("AllLanguages"))
 			{
 				SetupManager(folder);
-				var cultures = new List<CultureInfo>(LocalizationManager.GetUILanguages(true));
+				var cultures = new List<L10NCultureInfo>(LocalizationManager.GetUILanguages(true));
 				Assert.AreEqual(4, cultures.Count);
 				Assert.AreEqual("ar", cultures[0].IetfLanguageTag);		// Arabic
 				Assert.AreEqual("en", cultures[1].IetfLanguageTag);		// English
@@ -258,7 +258,7 @@ namespace L10NSharp.Tests
 				using (var folder = new TempFolder("AllLanguages"))
 				{
 					SetupManager(folder);
-					var cultures = new List<CultureInfo>(LocalizationManager.GetUILanguages(true));
+					var cultures = new List<L10NCultureInfo>(LocalizationManager.GetUILanguages(true));
 					Assert.AreEqual(4, cultures.Count);
 					Assert.AreEqual("ar", cultures[0].IetfLanguageTag);		// Arabic
 					Assert.AreEqual("en", cultures[1].IetfLanguageTag);		// English


### PR DESCRIPTION
We can't depend on CultureInfo working for every language that our
programs may be localized into.  Mono 4 throws exceptions while
.Net 4.6.1 creates generally worthless objects for languages that
the authors didn't know about or didn't consider worth implementing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/28)
<!-- Reviewable:end -->
