### PR TITLE
Fix L10NCultureInfo_TestPbu to pass on Windows

### DIFF
--- a/src/L10NSharpTests/L10NCultureInfoTests.cs
+++ b/src/L10NSharpTests/L10NCultureInfoTests.cs
@@ -27,7 +27,17 @@ namespace L10NSharp.Tests
 		{
 			var pbuci = L10NCultureInfo.GetCultureInfo("pbu");
 			Assert.AreEqual("Northern Pashto", pbuci.EnglishName);
+			// Linux/Mono4 and Windows7 will have null for pbuci.RawCultureInfo.
+			// Windows10 will produce a dummy object with no read information.
+#if __MonoCS__
 			Assert.IsNull(pbuci.RawCultureInfo);
+#else
+			if (pbuci.RawCultureInfo != null)
+			{
+				Assert.AreEqual("pbu", pbuci.RawCultureInfo.Name);
+				Assert.AreEqual("Unknown Language (pbu)", pbuci.RawCultureInfo.EnglishName);
+			}
+#endif
 		}
 
 		[Test]


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/30)
<!-- Reviewable:end -->
