### PR TITLE
BL-5272 Give a better error message for disposed LM

### DIFF
--- a/src/L10NSharpTests/LocalizationManagerTests.cs
+++ b/src/L10NSharpTests/LocalizationManagerTests.cs
@@ -203,7 +203,24 @@ namespace L10NSharp.Tests
 			}
 		}
 
-		//NOTE: the TestName parameter is only here to work around an NUnit bug in which 
+		[Test]
+		public void GetDynamicStringOrEnglish_LmDisposed_GivesUsefulException()
+		{
+			using (var folder = new TempFolder("GetDynamicStringOrEnglish_LmDisposed_GivesUsefulException"))
+			{
+				SetupManager(folder, "en");
+				Assert.That(LocalizationManager.GetDynamicString(AppId, "blahId", null), Is.EqualTo("blah"), "With no default supplied, should find saved English");
+				var extra = new LocalizationManager("nonsense", "more nonsense", "1.0");
+				LocalizationManager.LoadedManagers.Add(extra.Id, extra);
+				LocalizationManager.LoadedManagers[AppId].Dispose();
+				Assert.Throws<ObjectDisposedException>(() => LocalizationManager.GetDynamicString(AppId, "blahId", null));
+				extra.Dispose();
+				// A different path when there are none left
+				Assert.Throws<ObjectDisposedException>(() => LocalizationManager.GetDynamicString(AppId, "blahId", null));
+			}
+		}
+
+		//NOTE: the TestName parameter is only here to work around an NUnit bug in which
 		//NUnit doesn't run alll the test cases when some differ only by the values in an array parameter
 		//cases where we expect to get back the english in the code
 		[TestCase(new[] { "en" }, "blahInEnglishCode", "en", TestName = "GetString_OverloadThatTakesListOfLanguages_Works_1")]
@@ -295,7 +312,7 @@ namespace L10NSharp.Tests
 			}
 		}
 
-		//NOTE: the TestName parameter is only here to work around an NUnit bug in which 
+		//NOTE: the TestName parameter is only here to work around an NUnit bug in which
 		//NUnit doesn't run alll the test cases when some differ only by the values in an array parameter
 		//cases where we expect to get back the english in the code
 		[TestCase(new[] { "en" }, "blahInEnglishCode", "en", TestName = "GetString_OverloadThatTakesListOfLanguages_Works_1")]


### PR DESCRIPTION
At least in one case, where we're specifically asking for a string from a particular LM, we can report if it has been disposed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/31)
<!-- Reviewable:end -->
