### PR TITLE
Add IgnoreExistingEnglishXliffFiles global flag

### DIFF
--- a/src/ExtractXliff/ExtractXliff.csproj
+++ b/src/ExtractXliff/ExtractXliff.csproj
@@ -24,7 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
-    <Commandlineparameters>-v -n Bloom -o Bloom.exe -p 3.1.000.0 -x /tmp/Bloom.xlf -b /d/github/BloomV4.0/DistFiles/localization/en/Bloom.xlf /d/github/BloomV4.0/output/Debug/Bloom.exe</Commandlineparameters>
+    <Commandlineparameters>-v -n Bloom -o Bloom.exe -p 3.1.000.0 -x /tmp/Bloom.xlf -b /d/github/BloomMaster/DistFiles/localization/en/Bloom.xlf /d/github/BloomMaster/output/Debug/Bloom.exe</Commandlineparameters>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/L10NSharp/LocalizedStringCache.cs
+++ b/src/L10NSharp/LocalizedStringCache.cs
@@ -93,9 +93,12 @@ namespace L10NSharp
 			// (b) any newly obsolete IDs are noted.
 			if (File.Exists(OwningManager.DefaultInstalledStringFilePath))
 			{
-				var defaultInstalledXliffDoc = XLiffDocument.Read(OwningManager.DefaultInstalledStringFilePath);
-				foreach (var tu in defaultInstalledXliffDoc.File.Body.TransUnits)
-					DefaultXliffDocument.File.Body.AddTransUnitOrVariantFromExisting(tu, LocalizationManager.kDefaultLang);
+				if (!LocalizationManager.ScanningForCurrentStrings)
+				{
+					var defaultInstalledXliffDoc = XLiffDocument.Read(OwningManager.DefaultInstalledStringFilePath);
+					foreach (var tu in defaultInstalledXliffDoc.File.Body.TransUnits)
+						DefaultXliffDocument.File.Body.AddTransUnitOrVariantFromExisting(tu, LocalizationManager.kDefaultLang);
+				}
 			}
 			XliffDocuments.Add(LocalizationManager.kDefaultLang, DefaultXliffDocument);
 
@@ -276,7 +279,7 @@ namespace L10NSharp
 				if (tuTarget != null)
 					tuv = tuTarget.GetVariantForLang(langId);
 				// REVIEW: should we write units with no translation (target)?
-				var newTu = new TransUnit { Id = tu.Id };
+				var newTu = new TransUnit { Id = tu.Id, Dynamic = tu.Dynamic };
 				newTu.AddOrReplaceVariant(tu.GetVariantForLang(LocalizationManager.kDefaultLang));
 				if (tuv != null)
 					newTu.AddOrReplaceVariant(tuv);

--- a/src/L10NSharp/TransUnitUpdater.cs
+++ b/src/L10NSharp/TransUnitUpdater.cs
@@ -130,6 +130,7 @@ namespace L10NSharp
 			{
 				tu.Dynamic = true;
 				_updated = true;
+				Console.WriteLine("DEBUG: mark {0} trans-unit dynamic id=\"{1}\"; text=\"{2}\"", xliffTarget.File.Original, tu.Id, tu.Source.Value);
 			}
 			if ((locInfo.UpdateFields & UpdateFields.Comment) != UpdateFields.Comment)
 				return;
@@ -193,6 +194,9 @@ namespace L10NSharp
 			{
 				tuTarget = new TransUnit();
 				tuTarget.Id = tuId;
+				tuTarget.Dynamic = locInfo.DiscoveredDynamically;
+				if (locInfo.DiscoveredDynamically)
+					Console.WriteLine("DEBUG: {0} dynamic trans-unit id=\"{1}\"; text=\"{2}\"", xliffTarget.File.Original, tuId, newValue);
 				xliffTarget.AddTransUnit(tuTarget);
 				if (tuSource != null && locInfo.LangId != _defaultLang)
 				{


### PR DESCRIPTION
Also move XLiffDocument merging code to LocalizationManager.  The new
code helps in harvesting strings from running a program to verify which
strings in existing xliff files may be outdated and which strings need
to be added or updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/33)
<!-- Reviewable:end -->
