### PR TITLE
Improve the CheckOrFixXliff program in several ways

### DIFF
--- a/src/L10NSharp/LocalizedStringCache.cs
+++ b/src/L10NSharp/LocalizedStringCache.cs
@@ -797,10 +797,12 @@ namespace L10NSharp
 		}
 
 		/// <summary>
-		/// Fix any mangled format substitution markers that we can.  Almost all of the problems I've seen are due
+		/// Fix any mangled format substitution markers that we can.  Most of the problems I've seen are due
 		/// to confusion in RTL scripts.  The following regular expression operations fix the patterns of mistakes
 		/// that I've seen.  The first four would look okay visually in RTL scripts even though the underlying
 		/// string is wrong.
+		/// The other mistake I've seen is translating the number inside the curly brackets.  Bengali is the only
+		/// language with an occurrence of this problem so far.
 		/// </summary>
 		/// <remarks>
 		/// Note that \u200E is 'LEFT-TO-RIGHT MARK' and \u200F is 'RIGHT-TO-LEFT MARK'.
@@ -813,7 +815,12 @@ namespace L10NSharp
 			var target4 = Regex.Replace(target3, "{\u200E{([0-9]+)\u200F*", "\u200E{$1}\u200F", RegexOptions.CultureInvariant);
 			var target5 = Regex.Replace(target4, "'{\u200E([0-9]+)}'\u200F*", "\u200E'{$1}'\u200F", RegexOptions.CultureInvariant);
 			var target6 = Regex.Replace(target5, "{\u200E([0-9]+)}\u200F*", "\u200E{$1}\u200F", RegexOptions.CultureInvariant);
-			return target6;
+			// Bengali numbers
+			var target7 = target6.Replace("{\u09E6}", "{0}").Replace("{\u09E7}", "{1}").Replace("{\u09E8}", "{2}")
+								.Replace("{\u09E9}", "{3}").Replace("{\u09EA}", "{4}").Replace("{\u09EB}", "{5}")
+								.Replace("{\u09EC}", "{6}").Replace("{\u09ED}", "{7}").Replace("{\u09EE}", "{8}")
+								.Replace("{\u09EF}", "{9}");
+			return target7;
 		}
 	}
 }

--- a/src/L10NSharpTests/LocalizedStringCacheTests.cs
+++ b/src/L10NSharpTests/LocalizedStringCacheTests.cs
@@ -25,6 +25,8 @@ namespace L10NSharp.Tests
 		[TestCase(1, "\u0647 '{\u200E0}'\u200F \u0627", false, TestName="CheckSubstitutionMarkers_15")]
 		[TestCase(1, "\u062A\u0646 {\u200E {0 \u0631", false, TestName="CheckSubstitutionMarkers_16")]
 		[TestCase(1, "\u0632\u0020\"{\u200E\"{0\u200F.", false, TestName="CheckSubstitutionMarkers_17")]
+
+		[TestCase(3, "{\u09E6} \u09A7\u09B0\u09A3\u09BE '{1}' \u09AC\u09B9\u09BE\u09B0 {\u09E8}pt.", false, TestName="CheckSubstitutionMarkers_18")]
 		public void CheckStringsForValidSubstitionMarkers(int markerCount, string formatting, bool isValid)
 		{
 			Assert.That(LocalizedStringCache.CheckForValidSubstitutionMarkers(markerCount, formatting, "a.b"), Is.EqualTo(isValid));
@@ -37,13 +39,18 @@ namespace L10NSharp.Tests
 		[TestCase("\u0627\u06CC {\u200E0}\u200F \u0627", "\u0627\u06CC \u200E{0}\u200F \u0627",  TestName = "FixBrokenFormattingString_Works_4")]
 		[TestCase("\u0627\u06CC {\u200E{0",              "\u0627\u06CC \u200E{0}\u200F",         TestName = "FixBrokenFormattingString_Works_5")]
 		[TestCase("\u0647 '{\u200E0}'\u200F \u0627",     "\u0647 \u200E'{0}'\u200F \u0627",      TestName = "FixBrokenFormattingString_Works_6")]
-		[TestCase("\u062A\u0646 {\u200E {0 \u0631",      "\u062A\u0646 \u200E{0}\u200F  \u0631",  TestName = "FixBrokenFormattingString_Works_7")]
+		[TestCase("\u062A\u0646 {\u200E {0 \u0631",      "\u062A\u0646 \u200E{0}\u200F  \u0631", TestName = "FixBrokenFormattingString_Works_7")]
 		[TestCase("\u0632 \"{\u200E\"{0\u200F.",         "\u0632 \u200E\"{0}\"\u200F.",          TestName = "FixBrokenFormattingString_Works_8")]
+
+		[TestCase("{\u09E6} \u09A7\u09B0\u09A3",         "{0} \u09A7\u09B0\u09A3",               TestName = "FixBrokenFormattingString_Works_9")]
+		[TestCase("{\u09E6} \u09A7\u09B0\u09A3\u09BE '{1}' \u09AC\u09B9\u09BE\u09B0 {\u09E8}pt.",
+						"{0} \u09A7\u09B0\u09A3\u09BE '{1}' \u09AC\u09B9\u09BE\u09B0 {2}pt.",    TestName = "FixBrokenFormattingString_Works_10")]
 		public void TryToFixBrokenSubstitutionMarkers(string badFormat, string goodFormat)
 		{
 			var result = LocalizedStringCache.FixBrokenFormattingString(badFormat);
 			Assert.That(result, Is.EqualTo(goodFormat));
-			Assert.That(LocalizedStringCache.CheckForValidSubstitutionMarkers(1, result, "a.b"), Is.True);
+			// Check for the maximum number of possible substitution markers: unused arguments don't matter for validity.
+			Assert.That(LocalizedStringCache.CheckForValidSubstitutionMarkers(3, result, "a.b"), Is.EqualTo(true));
 		}
 	}
 }


### PR DESCRIPTION
1) Write an error message for invalid XML (oops...)
2) Fix substitution markers with improperly translated Bengali numbers
3) Return error code to allow use in scripts

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/38)
<!-- Reviewable:end -->
