### PR TITLE
Add methods for obtaining translation counts (BL-5472)

### DIFF
--- a/src/L10NSharp/LocalizationManager.cs
+++ b/src/L10NSharp/LocalizationManager.cs
@@ -448,6 +448,88 @@ namespace L10NSharp
 		}
 
 		/// <summary>
+		/// Return the number of strings that appear to have been translated and approved for the
+		/// given language in all the loaded managers.
+		/// </summary>
+		public static int NumberApproved(string lang)
+		{
+			if (lang == kDefaultLang)
+				return StringCount(lang);
+			var approved = 0;
+			foreach (var lm in s_loadedManagers.Values)
+			{
+				XLiffDocument xdoc;
+				if (lm.StringCache.XliffDocuments.TryGetValue(lang, out xdoc))
+					approved += xdoc.NumberApproved;
+			}
+			return approved;
+		}
+
+		/// <summary>
+		/// Return the fraction of strings that appear to have been translated and approved for the
+		/// given language in all the loaded managers.
+		/// </summary>
+		public static float FractionApproved(string lang)
+		{
+			if (lang == kDefaultLang)
+				return 1.0F;
+			var total = Math.Max(StringCount(lang), StringCount(kDefaultLang));
+			if (total == 0)
+				return 0.0F;
+			var approved = NumberApproved(lang);
+			return (float)approved / (float)total;
+		}
+
+		/// <summary>
+		/// Return the number of strings that appear to have been translated for the given language
+		/// in all the loaded managers.
+		/// </summary>
+		public static int NumberTranslated(string lang)
+		{
+			if (lang == kDefaultLang)
+				return StringCount(lang);
+			var translated = 0;
+			foreach (var lm in s_loadedManagers.Values)
+			{
+				XLiffDocument xdoc;
+				if (lm.StringCache.XliffDocuments.TryGetValue(lang, out xdoc))
+					translated += xdoc.NumberTranslated;
+			}
+			return translated;
+		}
+
+		/// <summary>
+		/// Return the fraction of strings that appear to have been translated for the given language
+		/// in all the loaded managers.
+		/// </summary>
+		public static float FractionTranslated(string lang)
+		{
+			if (lang == kDefaultLang)
+				return 1.0F;
+			var total = Math.Max(StringCount(lang), StringCount(kDefaultLang));
+			if (total == 0)
+				return 0.0F;
+			var translated = NumberTranslated(lang);
+			return (float)translated / (float)total;
+		}
+
+		/// <summary>
+		/// Return the number of strings that appear to be available for the given language in all
+		/// the loaded managers.
+		/// </summary>
+		public static int StringCount(string lang)
+		{
+			var count = 0;
+			foreach (var lm in s_loadedManagers.Values)
+			{
+				XLiffDocument xdoc;
+				if (lm.StringCache.XliffDocuments.TryGetValue(lang, out xdoc))
+					count += xdoc.StringCount;
+			}
+			return count;
+		}
+
+		/// <summary>
 		/// If the given file exists, return its parent folder name as a language tag if it
 		/// appears to be valid (2 or 3 letters long or "zh-CN").  Otherwise return null.
 		/// </summary>

--- a/src/L10NSharp/XLiffUtils/TransUnit.cs
+++ b/src/L10NSharp/XLiffUtils/TransUnit.cs
@@ -31,6 +31,7 @@ namespace L10NSharp.XLiffUtils
 		{
 			Source = new TransUnitVariant();
 			Target = null;
+			TranslationStatus = Status.Unapproved;
 		}
 
 		#region Properties
@@ -38,6 +39,23 @@ namespace L10NSharp.XLiffUtils
 		/// ------------------------------------------------------------------------------------
 		[XmlAttribute("id")]
 		public string Id { get; set; }
+
+		//  approved="yes"
+
+		public enum Status
+		{
+			[XmlEnumAttribute("yes")]
+			Approved,
+			[XmlEnumAttribute("no")]
+			Unapproved
+		}
+
+		/// <summary>
+		/// The state of a target element.
+		/// </summary>
+		[XmlAttribute("approved"), System.ComponentModel.DefaultValue(Status.Unapproved)]
+		public Status TranslationStatus;
+
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>

--- a/src/L10NSharp/XLiffUtils/TransUnitVariant.cs
+++ b/src/L10NSharp/XLiffUtils/TransUnitVariant.cs
@@ -23,6 +23,11 @@ namespace L10NSharp.XLiffUtils
 	[XmlType("source", Namespace = "urn:oasis:names:tc:xliff:document:1.2")]
 	public class TransUnitVariant : XLiffBaseWithNotesAndProps
 	{
+		public TransUnitVariant()
+		{
+			TargetState = TranslationState.Undefined;
+		}
+
 		#region Properties
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -31,6 +36,41 @@ namespace L10NSharp.XLiffUtils
 		/// ------------------------------------------------------------------------------------
 		[XmlAttribute("xml:lang")]
 		public string Lang { get; set; }
+
+		// Crowdin uses only "needs-translated" and "translated" as far as I can tell.  It appears to remove
+		// this attribute ("undefined") and use the "approved" attribute on the the trans-unit element to
+		// signal that it's been "reviewed and approved".
+		public enum TranslationState
+		{
+			[XmlEnumAttribute("undefined")]
+			Undefined,
+			[XmlEnumAttribute("translated")]				// Indicates that the item has been translated.
+			Translated,
+			[XmlEnumAttribute("needs-translation")]			// Indicates that the item needs to be translated.
+			NeedsTranslation,
+			[XmlEnumAttribute("final")]						// Indicates the terminating state.
+			Final,
+			[XmlEnumAttribute("needs-adaptation")]			//Indicates only non-textual information needs adaptation.
+			NeedsAdaptation,
+			[XmlEnumAttribute("needs-l10n")]				// Indicates both text and non-textual information needs adaptation.
+			NeedsLocalization,
+			[XmlEnumAttribute("needs-review-adaptation")]	// Indicates only non-textual information needs review.
+			AdaptationNeedsReview,
+			[XmlEnumAttribute("needs-review-l10n")]			// Indicates both text and non-textual information needs review.
+			LocalizationNeedsReview,
+			[XmlEnumAttribute("needs-review-translation")]	// Indicates that only the text of the item needs to be reviewed.
+			TranslationNeedsReview,
+			[XmlEnumAttribute("new")]						// Indicates that the item is new. For example, translation units that were not in a previous version of the document.
+			New,
+			[XmlEnumAttribute("signed-off")]				// Indicates that changes are reviewed and approved.
+			SignedOff
+		};
+
+		/// <summary>
+		/// The state of a target element.
+		/// </summary>
+		[XmlAttribute("state"), System.ComponentModel.DefaultValue(TranslationState.Undefined)]
+		public TranslationState TargetState;
 
         /// ------------------------------------------------------------------------------------
         /// <summary>

--- a/src/L10NSharp/XLiffUtils/XLiffBody.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffBody.cs
@@ -13,6 +13,7 @@
 // <remarks>
 // </remarks>
 // ---------------------------------------------------------------------------------------------
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Xml.Serialization;
@@ -30,6 +31,8 @@ namespace L10NSharp.XLiffUtils
 		private int _transUnitId;
 		private bool _idsVerified;
 		private List<TransUnit> _transUnits = new List<TransUnit>();
+		private int _translatedCount = -1;
+		private int _approvedCount = -1;
 
 		#region Properties
 		/// ------------------------------------------------------------------------------------
@@ -176,6 +179,71 @@ namespace L10NSharp.XLiffUtils
 
 		#endregion
 
+		/// <summary>
+		/// Return the number of the strings that appear to be translated.
+		/// </summary>
+		/// <remarks>
+		/// This value never changes once it is set.
+		/// </remarks>
+		internal int NumberTranslated
+		{
+			get
+			{
+				if (_translatedCount < 0)
+				{
+					_translatedCount = 0;
+					foreach (var tu in TransUnits)
+					{
+						if (tu.Target == null || String.IsNullOrWhiteSpace(tu.Target.Value))
+							continue;
+						if (tu.TranslationStatus == TransUnit.Status.Approved ||
+							tu.Target.TargetState == TransUnitVariant.TranslationState.Translated)
+						{
+							++_translatedCount;
+						}
+						else if (tu.Target.Value != tu.Source.Value &&
+							tu.Target.TargetState == TransUnitVariant.TranslationState.Undefined)
+						{
+							++_translatedCount;
+						}
+					}
+				}
+				return _translatedCount;
+			}
+		}
+
+		/// <summary>
+		/// Return the number of the strings that are translated and marked approved.
+		/// </summary>
+		/// <remarks>
+		/// This value never changes once it is set.
+		/// </remarks>
+		internal int NumberApproved
+		{
+			get
+			{
+				if (_approvedCount < 0)
+				{
+					_approvedCount = 0;
+					foreach (var tu in TransUnits)
+					{
+						if (tu.Target == null || String.IsNullOrWhiteSpace(tu.Target.Value))
+							continue;
+						if (tu.TranslationStatus == TransUnit.Status.Approved)
+							++_approvedCount;
+					}
+				}
+				return _approvedCount;
+			}
+		}
+
+		/// <summary>
+		/// Return the total number of strings.
+		/// </summary>
+		internal int StringCount
+		{
+			get { return TransUnits.Count; }
+		}
 	}
 
 	#endregion

--- a/src/L10NSharp/XLiffUtils/XLiffDocument.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffDocument.cs
@@ -164,6 +164,36 @@ namespace L10NSharp.XLiffUtils
 		{
 			 return File.Body.GetTransUnitForOrphan(orphan);
 		}
+
+		/// <summary>
+		/// Return the total number of strings.
+		/// </summary>
+		public int StringCount
+		{
+			get { return File.Body.StringCount; }
+		}
+
+		/// <summary>
+		/// Return the number of strings that appear to be translated.
+		/// </summary>
+		/// <remarks>
+		/// This value never changes once it is set.
+		/// </remarks>
+		public int NumberTranslated
+		{
+			get { return File.Body.NumberTranslated; }
+		}
+
+		/// <summary>
+		/// Return the number of strings that are translated and marked approved.
+		/// </summary>
+		/// <remarks>
+		/// This value never changes once it is set.
+		/// </remarks>
+		public int NumberApproved
+		{
+			get { return File.Body.NumberApproved; }
+		}
 	}
 
 

--- a/src/L10NSharpTests/LocalizationManagerTests.cs
+++ b/src/L10NSharpTests/LocalizationManagerTests.cs
@@ -424,6 +424,7 @@ namespace L10NSharp.Tests
 			var tu = new TransUnit
 			{
 				Id = "theId",
+				TranslationStatus = TransUnit.Status.Approved,
 				Source = new TransUnitVariant {Lang = "en", Value = "wrong"},
 				Target = new TransUnitVariant {Lang = "ar", Value = "inArabic"},
 				Notes = { new XLiffNote {Text = "Test"} }
@@ -433,6 +434,7 @@ namespace L10NSharp.Tests
 			var tu2 = new TransUnit
 			{
 				Id = "notUsedId",
+				TranslationStatus = TransUnit.Status.Approved,
 				Source = new TransUnitVariant {Lang = "en", Value = "inEnglishpartofArabicXliff"},
 				Target = new TransUnitVariant {Lang = "ar", Value = "inArabic"}
 			};
@@ -466,6 +468,7 @@ namespace L10NSharp.Tests
 			var tu = new TransUnit
 			{
 				Id = "theId",
+				TranslationStatus = TransUnit.Status.Approved,
 				Source = new TransUnitVariant {Lang = "en", Value = "from English Xliff"},
 				Target = new TransUnitVariant {Lang = "es", Value = "from Spanish Xliff"},
 				Notes = { new XLiffNote {Text = "Test"} }
@@ -475,6 +478,7 @@ namespace L10NSharp.Tests
 			var tu2 = new TransUnit
 			{
 				Id = "notUsedId",
+				TranslationStatus = TransUnit.Status.Approved,
 				Source = new TransUnitVariant {Lang = "en", Value = "no longer used English text"},
 				Target = new TransUnitVariant {Lang = "es", Value = "no longer used Spanish text"}
 			};
@@ -499,6 +503,7 @@ namespace L10NSharp.Tests
 			var tu2 = new TransUnit
 			{
 				Id = "notUsedId",
+				TranslationStatus = TransUnit.Status.Approved,
 				Source = new TransUnitVariant {Lang = "en", Value = "no longer used English text"},
 				Target = new TransUnitVariant {Lang = langId, Value = "no longer used Random text"}
 			};
@@ -800,6 +805,29 @@ namespace L10NSharp.Tests
 				// The actual stored value, that would be written to the xliff, should have the replacement text in it.
 				Assert.That(manager.StringCache.GetValueForExactLangAndId("fr", "anotherId", false), Is.EqualTo("Three\\nlines of\\nFrench"));
 				Assert.That(LocalizationManager.GetString("anotherId", "Three\r\nlines of" + Environment.NewLine + "English"), Is.EqualTo("Three" + LocalizedStringCache.kOSRealNewline + "lines of" + LocalizedStringCache.kOSRealNewline + "French"));
+			}
+		}
+
+		[Test]
+		public void TestFractionsTranslatedAndApproved()
+		{
+			LocalizationManager.UseLanguageCodeFolders = true;
+			using (var folder = new TempFolder("TestFractionsTranslatedAndApproved"))
+			{
+				AddRandomXliff("ii", GetInstalledDirectory(folder));
+				SetupManager(folder, "ii" /* UI language not important */);
+
+				Assert.That(LocalizationManager.FractionTranslated("en"), Is.EqualTo(1.0F));
+				Assert.That(LocalizationManager.FractionTranslated("ar"), Is.EqualTo(2F/3F));
+				Assert.That(LocalizationManager.FractionTranslated("es"), Is.EqualTo(1.0F));
+				Assert.That(LocalizationManager.FractionTranslated("fr"), Is.EqualTo(1F/3F));
+				Assert.That(LocalizationManager.FractionTranslated("ii"), Is.EqualTo(1F/3F));
+
+				Assert.That(LocalizationManager.FractionApproved("en"), Is.EqualTo(1.0F));
+				Assert.That(LocalizationManager.FractionApproved("ar"), Is.EqualTo(2F/3F));
+				Assert.That(LocalizationManager.FractionApproved("es"), Is.EqualTo(2F/3F));
+				Assert.That(LocalizationManager.FractionApproved("fr"), Is.EqualTo(0.0F));
+				Assert.That(LocalizationManager.FractionApproved("ii"), Is.EqualTo(1F/3F));
 			}
 		}
 	}

--- a/src/L10NSharpTests/TestXliff/Test.es.xlf
+++ b/src/L10NSharpTests/TestXliff/Test.es.xlf
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff">
+  <file source-language="en" target-language="es-ES" product-version="1.0.0.0"  original="Palaso.dll" datatype="csharp" sil:hard-linebreak-replacement="\n">
+    <body>
+      <trans-unit id="SettingsProtection.CtrlShiftHint" approved="yes">
+        <source xml:lang="en">The button will show up when you hold down the Ctrl and Shift keys together.</source>
+        <target xml:lang="es-ES">El botón se mostrará cuando se mantengan presionadas juntas las teclas Ctrl y Mayús.</target>
+        <alt-trans>
+          <target xml:lang="es-ES">El botón se mostrará cuando juntamente se presiona las teclas Ctrl y Mayús.</target>
+        </alt-trans>
+        <note>ID: SettingsProtection.CtrlShiftHint</note>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.LauncherButtonLabel">
+        <source xml:lang="en">Settings Protection...</source>
+        <target xml:lang="es-ES" state="translated">Protección de configuraciones...</target>
+        <note>ID: SettingsProtection.LauncherButtonLabel</note>
+        <note xml:lang="en">OLD TEXT (before 4.0): Settings...</note>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox" approved="yes">
+        <source xml:lang="en">Hide the button that opens settings.</source>
+        <target xml:lang="es-ES">Ocultar el botón que abre la configuración.</target>
+        <note>ID: SettingsProtection.NormallyHiddenCheckbox</note>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword">
+        <source xml:lang="en">Factory Password</source>
+        <target xml:lang="es-ES" state="needs-translation">Factory Password</target>
+        <note>ID: SettingsProtection.PasswordDialog.FactoryPassword</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/L10NSharpTests/XLiffUtilsTests.cs
+++ b/src/L10NSharpTests/XLiffUtilsTests.cs
@@ -36,6 +36,31 @@ namespace L10NSharp.Tests
 			// Test that what once was passed in a note is still being read correctly.
 			Assert.AreEqual("\\n", doc.File.HardLineBreakReplacement);
 		}
+
+		[Test]
+		public void TestCounts()
+		{
+			var enfile = Path.Combine(_testFolder, "Test.en.xlf");
+			var endoc = XLiffDocument.Read(enfile);
+			// These numbers may be counter-intuitive, but then the English isn't translated, is it?
+			// Code at the LocalizationManager level will make English look okay for display by
+			// faking the approved and translated counts.
+			Assert.AreEqual(4, endoc.StringCount);
+			Assert.AreEqual(0, endoc.NumberApproved);
+			Assert.AreEqual(0, endoc.NumberTranslated);
+
+			var frfile = Path.Combine(_testFolder, "Test.fr.xlf");
+			var frdoc = XLiffDocument.Read(frfile);
+			Assert.AreEqual(4, frdoc.StringCount);
+			Assert.AreEqual(0, frdoc.NumberApproved);
+			Assert.AreEqual(4, frdoc.NumberTranslated);
+
+			var esfile = Path.Combine(_testFolder, "Test.es.xlf");
+			var esdoc = XLiffDocument.Read(esfile);
+			Assert.AreEqual(4, esdoc.StringCount);
+			Assert.AreEqual(2, esdoc.NumberApproved);
+			Assert.AreEqual(3, esdoc.NumberTranslated);
+		}
 	}
 }
 


### PR DESCRIPTION
The counts include the number of strings, the number of strings that
appear to be translated, and the number of translated strings that
have been approved.  The second two numbers are also available as
fractions at the static LocalizationManager level.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/40)
<!-- Reviewable:end -->
