### PR TITLE
Handle null (or empty) language ids better (BL-5479)

### DIFF
--- a/src/L10NSharp/LocalizationManager.cs
+++ b/src/L10NSharp/LocalizationManager.cs
@@ -1054,6 +1054,8 @@ namespace L10NSharp
 		/// </summary>
 		private static string MapToExistingLanguageIfPossible(string langId)
 		{
+			if (string.IsNullOrEmpty(langId))
+				return langId;
 			string realId;
 			if (MapToExistingLanguage.TryGetValue(langId, out realId))
 				return realId;
@@ -1319,6 +1321,8 @@ namespace L10NSharp
 		/// ------------------------------------------------------------------------------------
 		public static bool GetIsStringAvailableForLangId(string id, string langId)
 		{
+			if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(langId))
+				return false;
 			var realLangId =  MapToExistingLanguageIfPossible(langId);
 			var str = LoadedManagers.Values.Select(lm => lm.StringCache.GetValueForExactLangAndId(realLangId, id, false))
 				.FirstOrDefault(txt => !string.IsNullOrEmpty(txt));


### PR DESCRIPTION
This fixes a crashing unit test in Bloom.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/45)
<!-- Reviewable:end -->
