### PR TITLE
Report the filename for a corrupted xlf file (BL-6420)

### DIFF
--- a/src/L10NSharp/LocalizedStringCache.cs
+++ b/src/L10NSharp/LocalizedStringCache.cs
@@ -168,13 +168,14 @@ namespace L10NSharp
 				}
 				catch (Exception e)
 				{
+					var msg = String.Format("Caught exception in MergeXliffFilesIntoCache [{0}] - {1}", file, e.Message);
 	#if DEBUG
-					throw new Exception("Caught exception in MergeXliffFilesIntoCache", e);
+					throw new Exception(msg, e);
 	#else
 					// If an error happened reading some localization file other than one we care
 					// about right now, just ignore it.
 					if (file == OwningManager.GetXliffPathForLanguage(LocalizationManager.UILanguageId, false))
-						error = new Exception("Caught exception in MergeXliffFilesIntoCache", e);
+						error = new Exception(msg, e);
 	#endif
 				}
 			}


### PR DESCRIPTION
This doesn't fix the reported crash, but does provide more specific information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/49)
<!-- Reviewable:end -->
