### PR TITLE
Adjust for mono 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 _ReSharper*
+.idea/
 output/
 obj/
 *.suo
@@ -11,3 +12,4 @@ bin/
 *.bak
 packages/
 build/NuGet.exe
+build/nuget.exe

--- a/src/L10NSharp/LocalizationManager.cs
+++ b/src/L10NSharp/LocalizationManager.cs
@@ -445,13 +445,14 @@ namespace L10NSharp
 				if (s_uiLangId == null)
 				{
 					s_uiLangId = Thread.CurrentThread.CurrentUICulture.Name;
-#if __MonoCS__
-					// The current version of Mono does not define a CultureInfo for "zh", so
-					// it tends to throw exceptions when we try to use just plain "zh".
-					if (s_uiLangId == "zh-CN")
-						return s_uiLangId;
+					if (Utils.IsMono)
+					{
+						// The current version of Mono does not define a CultureInfo for "zh", so
+						// it tends to throw exceptions when we try to use just plain "zh".
+						if (s_uiLangId == "zh-CN")
+							return s_uiLangId;
+					}
 					// Otherwise, we want the culture.neutral version.
-#endif
 					int i = s_uiLangId.IndexOf('-');
 					if (i >= 0)
 						s_uiLangId = s_uiLangId.Substring(0, i);
@@ -1060,7 +1061,7 @@ namespace L10NSharp
 		/// ------------------------------------------------------------------------------------
 		private static string GetStringFromAnyLocalizationManager(string stringId)
 		{
-			// Note: this is odd semantics to me (JH); looks to be part of the rule that we prefer the 
+			// Note: this is odd semantics to me (JH); looks to be part of the rule that we prefer the
 			// English from the program source to the English from the tmx.
 
 			// This will enforce that the text to localize is just returned to the caller

--- a/src/L10NSharp/UI/HowToDistributeDialog.cs
+++ b/src/L10NSharp/UI/HowToDistributeDialog.cs
@@ -13,18 +13,20 @@ namespace L10NSharp.UI
 			_targetTmxFilePath = targetTmxFilePath;
 			InitializeComponent();
 
-#if __MonoCS__
-			// In Mono, Label.AutoSize=true sets Size to PreferredSize (which is always
-			// one line high) even if the Size has already been explicitly set.  In Windows,
-			// Label.AutoSize=false makes the labels disappear.  So we need to turn off
-			// AutoSize here and set the multiline labels explicitly to their largest
-			// possible sizes for this fixed-size dialog.  (That allows all the available
-			// space for localizations that may need more space.)
-			label1.AutoSize = label2.AutoSize = label4.AutoSize = false;
-			label4.Size = new System.Drawing.Size(300, 142);	// top message
-			label2.Size = new System.Drawing.Size(300, 56);		// middle message
-			label1.Size = new System.Drawing.Size(300, 112);	// bottom message
-#endif
+			if (Utils.IsMono)
+			{
+				// In Mono, Label.AutoSize=true sets Size to PreferredSize (which is always
+				// one line high) even if the Size has already been explicitly set.  In Windows,
+				// Label.AutoSize=false makes the labels disappear.  So we need to turn off
+				// AutoSize here and set the multiline labels explicitly to their largest
+				// possible sizes for this fixed-size dialog.  (That allows all the available
+				// space for localizations that may need more space.)
+				label1.AutoSize = label2.AutoSize = label4.AutoSize = false;
+				label4.Size = new System.Drawing.Size(300, 142); // top message
+				label2.Size = new System.Drawing.Size(300, 56);  // middle message
+				label1.Size = new System.Drawing.Size(300, 112); // bottom message
+			}
+
 			_emailLabel.Text=emailForSubmissions;
 		}
 

--- a/src/L10NSharp/UI/Utils.cs
+++ b/src/L10NSharp/UI/Utils.cs
@@ -8,17 +8,33 @@ namespace L10NSharp.UI
 	/// ----------------------------------------------------------------------------------------
 	internal static class Utils
 	{
+		private static bool?  _isMono;
 
-#if !__MonoCS__
-		[DllImport("user32.dll", CharSet = CharSet.Auto)]
-		public static extern void SendMessage(IntPtr hWnd, int msg, int wParam, int lParam);
-#else
+		public static bool IsMono
+		{
+			get
+			{
+				if (_isMono == null)
+					_isMono = Type.GetType("Mono.Runtime")
+							!= null;
+
+				return (bool) _isMono;
+			}
+		}
+
+
+		[DllImport("user32.dll", CharSet = CharSet.Auto, EntryPoint = "SendMessage")]
+		private static extern void SendMessageWindows(IntPtr hWnd, int msg, int wParam, int lParam);
+
 		public static void SendMessage(IntPtr hWnd, int msg, int wParam, int lParam)
 		{
-			Console.WriteLine("Warning--using unimplemented method SendMessage"); // FIXME Linux
-			return;
+			if (IsMono)
+				Console.WriteLine("Warning--using unimplemented method SendMessage"); // FIXME Linux
+			else
+			{
+				SendMessageWindows(hWnd, msg, wParam, lParam);
+			}
 		}
-#endif
 
 
 		private const int WM_SETREDRAW = 0xB;
@@ -39,14 +55,16 @@ namespace L10NSharp.UI
 		{
 			if (ctrl != null && !ctrl.IsDisposed && ctrl.IsHandleCreated)
 			{
-#if !__MonoCS__
-				SendMessage(ctrl.Handle, WM_SETREDRAW, (turnOn ? 1 : 0), 0);
-#else
-				if (turnOn)
-					ctrl.ResumeLayout(invalidateAfterTurningOn);
+				if (IsMono)
+				{
+					if (turnOn)
+						ctrl.ResumeLayout(invalidateAfterTurningOn);
+					else
+						ctrl.SuspendLayout();
+				}
 				else
-					ctrl.SuspendLayout();
-#endif
+					SendMessage(ctrl.Handle, WM_SETREDRAW, (turnOn ? 1 : 0), 0);
+
 				if (turnOn && invalidateAfterTurningOn)
 					ctrl.Invalidate(true);
 			}


### PR DESCRIPTION
Mono 5 uses the Roslyn compiler (which is the same as on Windows) which
doesn't define `__MonoCS__`. This change modifies the code to check at
runtime whether we're running on Mono.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/51)
<!-- Reviewable:end -->
