### PR TITLE
Find TMX files in 'Generated' and 'User Modified' directories

### DIFF
--- a/src/L10NSharp/L10NSharp-Designer.csproj
+++ b/src/L10NSharp/L10NSharp-Designer.csproj
@@ -73,6 +73,7 @@
     <Compile Include="INote.cs" />
     <Compile Include="ITransUnit.cs" />
     <Compile Include="ITransUnitVariant.cs" />
+    <Compile Include="L10NSharpListExtensions.cs" />
     <Compile Include="TMXUtils\TMXBaseWithNotesAndProps.cs" />
     <Compile Include="TMXUtils\TMXBody.cs" />
     <Compile Include="TMXUtils\TMXDocument.cs" />

--- a/src/L10NSharp/L10NSharpListExtensions.cs
+++ b/src/L10NSharp/L10NSharpListExtensions.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace L10NSharp
+{
+	public static class L10NSharpListExtensions
+	{
+		public static void AddIfUniqueAndNotNull<T>(this List<T> list, T item)
+		{
+			if (item == null) return;
+
+			if (!list.Contains(item))
+				list.Add(item);
+		}
+	}
+}

--- a/src/L10NSharp/TMXUtils/TMXLocalizationManager.cs
+++ b/src/L10NSharp/TMXUtils/TMXLocalizationManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -1117,31 +1117,74 @@ namespace L10NSharp.TMXUtils
 		public IEnumerable<string> GetAvailableUILanguageTags()
 		{
 			var tags = new List<string>();
-			if (!Directory.Exists(_installedTmxFileFolder))
-				return tags;
+
 			if (LocalizationManager.UseLanguageCodeFolders)
 			{
-				foreach (var folder in Directory.GetDirectories(_installedTmxFileFolder))
+				if (Directory.Exists(_installedTmxFileFolder))
 				{
-					var tmxFile = Path.Combine(folder, $"{Id}{FileExtension}");
-					var langTag = GetLanguageTagFromFilePath(tmxFile);
-					if (langTag != null)
-						tags.Add(langTag);
+					foreach (var folder in Directory.GetDirectories(_installedTmxFileFolder))
+						tags.AddIfUniqueAndNotNull(GetLanguageTagFromFolderName(folder));
+				}
+
+				if (Directory.Exists(_generatedDefaultTmxFileFolder))
+				{
+					foreach (var folder in Directory.GetDirectories(_generatedDefaultTmxFileFolder))
+						tags.AddIfUniqueAndNotNull(GetLanguageTagFromFolderName(folder));
+				}
+
+				if (Directory.Exists(_customTmxFileFolder))
+				{
+					foreach (var folder in Directory.GetDirectories(_customTmxFileFolder))
+						tags.AddIfUniqueAndNotNull(GetLanguageTagFromFolderName(folder));
 				}
 			}
 			else
 			{
-				foreach (var filepath in Directory.GetFiles(_installedTmxFileFolder,
-					$"{Id}.*{FileExtension}"))
+				if (Directory.Exists(_installedTmxFileFolder))
 				{
-					var filename = Path.GetFileNameWithoutExtension(filepath);
-					var tag = filename.Substring(Id.Length + 1);
-					tags.Add(tag);
+					foreach (var filepath in Directory.GetFiles(_installedTmxFileFolder,
+						$"{Id}.*{FileExtension}"))
+						tags.AddIfUniqueAndNotNull(GetLanguageTagFromFileName(filepath));
+				}
+
+				if (Directory.Exists(_generatedDefaultTmxFileFolder))
+				{
+					foreach (var filepath in Directory.GetFiles(_generatedDefaultTmxFileFolder,
+						$"{Id}.*{FileExtension}"))
+						tags.AddIfUniqueAndNotNull(GetLanguageTagFromFileName(filepath));
+				}
+
+				if (Directory.Exists(_customTmxFileFolder))
+				{
+					foreach (var filepath in Directory.GetFiles(_customTmxFileFolder,
+						$"{Id}.*{FileExtension}"))
+						tags.AddIfUniqueAndNotNull(GetLanguageTagFromFileName(filepath));
 				}
 			}
 
 			return tags;
+		}
 
+		/// <summary>
+		/// Gets the language code from the folder name, if using language code folders
+		/// </summary>
+		/// <param name="folder"></param>
+		/// <returns></returns>
+		private string GetLanguageTagFromFolderName(string folder)
+		{
+			var tmxFile = Path.Combine(folder, $"{Id}{FileExtension}");
+			return GetLanguageTagFromFilePath(tmxFile);
+		}
+
+		/// <summary>
+		/// Gets the language code from the file name, if not using language code folders
+		/// </summary>
+		/// <param name="filePath"></param>
+		/// <returns></returns>
+		private string GetLanguageTagFromFileName(string filePath)
+		{
+			var fileName = Path.GetFileNameWithoutExtension(filePath);
+			return fileName?.Substring(Id.Length + 1);
 		}
 
 		/// <summary>

--- a/src/L10NSharpTests/LocalizationManagerTestsBase.cs
+++ b/src/L10NSharpTests/LocalizationManagerTestsBase.cs
@@ -401,7 +401,7 @@ namespace L10NSharp.Tests
 			return parentDir.Combine("generated");
 		}
 
-		private static string GetUserModifiedDirectory(TempFolder parentDir)
+		protected static string GetUserModifiedDirectory(TempFolder parentDir)
 		{
 			return parentDir.Combine("userModified");
 		}

--- a/src/L10NSharpTests/LocalizationManagerTestsBase.cs
+++ b/src/L10NSharpTests/LocalizationManagerTestsBase.cs
@@ -396,7 +396,7 @@ namespace L10NSharp.Tests
 			return parentDir.Path; // no reason we can't use the root temp dir for the "installed" Translation's
 		}
 
-		private static string GetGeneratedDirectory(TempFolder parentDir)
+		protected static string GetGeneratedDirectory(TempFolder parentDir)
 		{
 			return parentDir.Combine("generated");
 		}

--- a/src/L10NSharpTests/TMXLocalizationManagerTests.cs
+++ b/src/L10NSharpTests/TMXLocalizationManagerTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 using L10NSharp.TMXUtils;
@@ -82,16 +83,56 @@ namespace L10NSharp.Tests
 		}
 
 		[Test]
-		public void GetCustomUILanguageTags_FindsFiveLanguages()
+		public void GetAvailableUILanguageTags_AddRandomTranslation_FindsTmxFileInUserModifiedDirectory()
 		{
 			using (var folder = new TempFolder())
 			{
 				SetupManager(folder);
+
+				// add a custom localization in the User Modified directory
 				AddRandomTranslation("ii", GetUserModifiedDirectory(folder));
+
+				// load available localizations
 				var lm = LocalizationManager.LoadedManagers.Values.First();
 				var tags = lm.GetAvailableUILanguageTags().ToArray();
-				Assert.That(tags.Length, Is.EqualTo(5));
-				Assert.That(tags.Contains("ii"), Is.True);
+
+				// was the 'ii' tag found?
+				Assert.That(tags.Contains("ii"), Is.True,
+					"Tag 'ii' not found.");
+
+				// is the TMX file in the User Modified directory?
+				Assert.That(File.Exists(Path.Combine(GetUserModifiedDirectory(folder), "test.ii.tmx")), Is.True,
+					"File 'test.ii.tmx' not found in User Modified directory.");
+			}
+		}
+
+		[Test]
+		public void GetAvailableUILanguageTags_FindsEnglishTmxFileInGeneratedDirectory()
+		{
+			using (var folder = new TempFolder())
+			{
+				SetupManager(folder);
+
+				// remove the installed English TMX file
+				var installedEnglishFile = Path.Combine(GetInstalledDirectory(folder), "test.en.tmx");
+				Assert.That(File.Exists(installedEnglishFile), Is.True,
+					"File 'test.en.tmx' not found in Installed directory.");
+
+				File.Delete(installedEnglishFile);
+				Assert.That(File.Exists(installedEnglishFile), Is.False,
+					"File 'test.en.tmx' was not deleted.");
+
+				// load the remaining localizations
+				var lm = LocalizationManager.LoadedManagers.Values.First();
+				var tags = lm.GetAvailableUILanguageTags().ToArray();
+
+				// was the 'en' tag found?
+				Assert.That(tags.Contains("en"), Is.True,
+					"Tag 'en' not found.");
+
+				// is the TMX file in the Generated directory?
+				Assert.That(File.Exists(Path.Combine(GetGeneratedDirectory(folder), "test.en.tmx")), Is.True,
+					"File 'test.en.tmx' not found in Generated directory.");
 			}
 		}
 	}

--- a/src/L10NSharpTests/TMXLocalizationManagerTests.cs
+++ b/src/L10NSharpTests/TMXLocalizationManagerTests.cs
@@ -74,7 +74,6 @@ namespace L10NSharp.Tests
 			return new TMXTransUnitVariant { Lang = lang, Value = value };
 		}
 
-
 		protected override string GetGeneratedVersion(XElement xmlDoc)
 		{
 			var headerElt = xmlDoc.Element("header");
@@ -82,5 +81,18 @@ namespace L10NSharp.Tests
 			return verElement == null ? null : new Version(verElement.Value).ToString();
 		}
 
+		[Test]
+		public void GetCustomUILanguageTags_FindsFiveLanguages()
+		{
+			using (var folder = new TempFolder())
+			{
+				SetupManager(folder);
+				AddRandomTranslation("ii", GetUserModifiedDirectory(folder));
+				var lm = LocalizationManager.LoadedManagers.Values.First();
+				var tags = lm.GetAvailableUILanguageTags().ToArray();
+				Assert.That(tags.Length, Is.EqualTo(5));
+				Assert.That(tags.Contains("ii"), Is.True);
+			}
+		}
 	}
 }


### PR DESCRIPTION
The current 4.0 code is only looking for TMX files in the 'Installed' directory

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/62)
<!-- Reviewable:end -->
