### PR TITLE
Make TranslationManager.ReturnOnlyApprovedStrings behave dynamically

### DIFF
--- a/src/L10NSharp/XLiffUtils/XLiffBody.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffBody.cs
@@ -67,6 +67,8 @@ namespace L10NSharp.XLiffUtils
 		/// ------------------------------------------------------------------------------------
 		[XmlIgnore]
 		public readonly Dictionary<string, string> TranslationsById = new Dictionary<string, string>();
+		[XmlIgnore]
+		public readonly Dictionary<string, bool> ApprovalsById = new Dictionary<string, bool>();
 		#endregion
 
 
@@ -123,6 +125,7 @@ namespace L10NSharp.XLiffUtils
 				TranslationsById[tu.Id] = tu.Target.Value;
 			else
 				TranslationsById[tu.Id] = tu.Source.Value;
+			ApprovalsById[tu.Id] = tu.TranslationStatus == TranslationStatus.Approved;
 			return true;
 		}
 
@@ -147,6 +150,7 @@ namespace L10NSharp.XLiffUtils
 			//surely take precedence, as the translation for that language.
 			existingTu.AddOrReplaceVariant(variantToAdd);
 			TranslationsById[tu.Id] = variantToAdd.Value;
+			ApprovalsById[tu.Id] = tu.TranslationStatus == TranslationStatus.Approved;
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -172,7 +176,10 @@ namespace L10NSharp.XLiffUtils
 				}
 			}
 			if (tu.Id != null)
+			{
 				TranslationsById.Remove(tu.Id);
+				ApprovalsById.Remove(tu.Id);
+			}
 		}
 
 		#endregion

--- a/src/L10NSharp/XLiffUtils/XLiffLocalizedStringCache.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffLocalizedStringCache.cs
@@ -141,6 +141,11 @@ namespace L10NSharp.XLiffUtils
 									// adjust the document's internal cache
 									xliffDoc.File.Body.TranslationsById[movedUnit.Id] = xliffDoc.File.Body.TranslationsById[tu.Id];
 									xliffDoc.File.Body.TranslationsById.Remove(tu.Id);
+									if (xliffDoc.File.Body.ApprovalsById.ContainsKey(tu.Id))
+									{
+										xliffDoc.File.Body.ApprovalsById[movedUnit.Id] = xliffDoc.File.Body.ApprovalsById[tu.Id];
+										xliffDoc.File.Body.ApprovalsById.Remove(tu.Id);
+									}
 								}
 								tu.Id = movedUnit.Id;
 								xliffDoc.IsDirty = true;
@@ -443,6 +448,8 @@ namespace L10NSharp.XLiffUtils
 			if (!xliff.File.Body.TranslationsById.TryGetValue(id, out var value))
 				return null;
 			if (string.IsNullOrEmpty(value))
+				return null;
+			if (LocalizationManager.ReturnOnlyApprovedStrings && (!xliff.File.Body.ApprovalsById.ContainsKey(id) || !xliff.File.Body.ApprovalsById[id]))
 				return null;
 
 			if (formatForDisplay && s_literalNewline != null)

--- a/src/L10NSharp/XLiffUtils/XLiffTransUnitUpdater.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffTransUnitUpdater.cs
@@ -204,6 +204,7 @@ namespace L10NSharp.XLiffUtils
 			if (string.IsNullOrEmpty(newValue))
 			{
 				xliffTarget.File.Body.TranslationsById.Remove(tuId);
+				xliffTarget.File.Body.ApprovalsById.Remove(tuId);
 				return tuTarget;
 			}
 
@@ -227,6 +228,7 @@ namespace L10NSharp.XLiffUtils
 
 			tuTarget.AddOrReplaceVariant(locInfo.LangId, newValue);
 			xliffTarget.File.Body.TranslationsById[tuId] = newValue;
+			xliffTarget.File.Body.ApprovalsById[tuId] = false;
 			_updated = true;
 			return tuTarget;
 		}

--- a/src/L10NSharpTests/TestXliff/Test.en.xlf
+++ b/src/L10NSharpTests/TestXliff/Test.en.xlf
@@ -18,6 +18,18 @@
 		<trans-unit id="TestItem.Bird.Eagle">
 			<source xml:lang="en">Fish-eating bird</source>
 		</trans-unit>
+		<trans-unit id="TestItem.SettingsProtection.CtrlShiftHint">
+			<source xml:lang="en">The button will show up when you hold down the Ctrl and Shift keys together.</source>
+		</trans-unit>
+		<trans-unit id="TestItem.SettingsProtection.LauncherButtonLabel">
+			<source xml:lang="en">Settings Protection...</source>
+		</trans-unit>
+		<trans-unit id="TestItem.SettingsProtection.NormallyHiddenCheckbox">
+			<source xml:lang="en">Hide the button that opens settings.</source>
+		</trans-unit>
+		<trans-unit id="TestItem.SettingsProtection.PasswordDialog.FactoryPassword">
+			<source xml:lang="en">Factory Password</source>
+		</trans-unit>
 	</body>
 </file>
 </xliff>

--- a/src/L10NSharpTests/TestXliff/Test.es.xlf
+++ b/src/L10NSharpTests/TestXliff/Test.es.xlf
@@ -2,29 +2,29 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff">
   <file source-language="en" target-language="es-ES" product-version="1.0.0.0"  original="Palaso.dll" datatype="csharp" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="SettingsProtection.CtrlShiftHint" approved="yes">
+      <trans-unit id="TestItem.SettingsProtection.CtrlShiftHint" approved="yes">
         <source xml:lang="en">The button will show up when you hold down the Ctrl and Shift keys together.</source>
         <target xml:lang="es-ES">El botón se mostrará cuando se mantengan presionadas juntas las teclas Ctrl y Mayús.</target>
         <alt-trans>
           <target xml:lang="es-ES">El botón se mostrará cuando juntamente se presiona las teclas Ctrl y Mayús.</target>
         </alt-trans>
-        <note>ID: SettingsProtection.CtrlShiftHint</note>
+        <note>ID: TestItem.SettingsProtection.CtrlShiftHint</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.LauncherButtonLabel">
+      <trans-unit id="TestItem.SettingsProtection.LauncherButtonLabel">
         <source xml:lang="en">Settings Protection...</source>
         <target xml:lang="es-ES" state="translated">Protección de configuraciones...</target>
-        <note>ID: SettingsProtection.LauncherButtonLabel</note>
+        <note>ID: TestItem.SettingsProtection.LauncherButtonLabel</note>
         <note xml:lang="en">OLD TEXT (before 4.0): Settings...</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox" approved="yes">
+      <trans-unit id="TestItem.SettingsProtection.NormallyHiddenCheckbox" approved="yes">
         <source xml:lang="en">Hide the button that opens settings.</source>
         <target xml:lang="es-ES">Ocultar el botón que abre la configuración.</target>
-        <note>ID: SettingsProtection.NormallyHiddenCheckbox</note>
+        <note>ID: TestItem.SettingsProtection.NormallyHiddenCheckbox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword">
+      <trans-unit id="TestItem.SettingsProtection.PasswordDialog.FactoryPassword">
         <source xml:lang="en">Factory Password</source>
         <target xml:lang="es-ES" state="needs-translation">Factory Password</target>
-        <note>ID: SettingsProtection.PasswordDialog.FactoryPassword</note>
+        <note>ID: TestItem.SettingsProtection.PasswordDialog.FactoryPassword</note>
       </trans-unit>
     </body>
   </file>

--- a/src/L10NSharpTests/TestXliff/Test.fr.xlf
+++ b/src/L10NSharpTests/TestXliff/Test.fr.xlf
@@ -7,19 +7,19 @@
 	<body>	
 		<trans-unit id="TestItem.Bird.Crow">
 			<source xml:lang="en">It's a crow</source>
-			<target xml:lang="fr">C'est un corbeau</target>
+			<target xml:lang="fr" state="translated">C'est un corbeau</target>
 		</trans-unit>
 		<trans-unit id="TestItem.Bird.Raven">
 			<source xml:lang="en">It's not a crow</source>
-			<target xml:lang="fr">Ce n'est pas un corbeau</target>
+			<target xml:lang="fr" state="translated">Ce n'est pas un corbeau</target>
 		</trans-unit>
 		<trans-unit id="TestItem.Chicken.Rooster">
 			<source xml:lang="en">It's a chicken</source>
-			<target xml:lang="fr">C'est un poulet</target>
+			<target xml:lang="fr" state="translated">C'est un poulet</target>
 		</trans-unit>
 		<trans-unit id="TestItem.Bird.Eagle">
 			<source xml:lang="en">Fish-eating bird</source>
-			<target xml:lang="fr">Un oiseau qui mange des poissons</target>
+			<target xml:lang="fr" state="translated">Un oiseau qui mange des poissons</target>
 		</trans-unit>
 	</body>	
 </file>

--- a/src/L10NSharpTests/XLiffUtilsTests.cs
+++ b/src/L10NSharpTests/XLiffUtilsTests.cs
@@ -46,7 +46,7 @@ namespace L10NSharp.Tests
 			// These numbers may be counter-intuitive, but then the English isn't translated, is it?
 			// Code at the LocalizationManagerInternal level will make English look okay for display by
 			// faking the approved and translated counts.
-			Assert.AreEqual(4, endoc.StringCount);
+			Assert.AreEqual(8, endoc.StringCount);
 			Assert.AreEqual(0, endoc.NumberApproved);
 			Assert.AreEqual(0, endoc.NumberTranslated);
 
@@ -64,15 +64,16 @@ namespace L10NSharp.Tests
 		}
 
 		[Test]
-		public void TestReturningAllStrings()
+		public void TestLoadingAllStringsAndApprovals()
 		{
 			var enfile = Path.Combine(_testFolder, "Test.en.xlf");
 			var endoc = XLiffDocument.Read(enfile);
 			// These numbers may be counter-intuitive, but then the English isn't translated, is it?
 			// Code at the LocalizationManagerInternal level will make English look okay for display by
 			// faking the approved and translated counts.
-			Assert.AreEqual(4, endoc.StringCount);
+			Assert.AreEqual(8, endoc.StringCount);
 			string source;
+			bool approved;
 			Assert.IsTrue(endoc.File.Body.TranslationsById.TryGetValue("TestItem.Bird.Crow", out source));
 			Assert.AreEqual("It's a crow", source);
 			Assert.IsTrue(endoc.File.Body.TranslationsById.TryGetValue("TestItem.Bird.Raven", out source));
@@ -81,6 +82,30 @@ namespace L10NSharp.Tests
 			Assert.AreEqual("It's a chicken", source);
 			Assert.IsTrue(endoc.File.Body.TranslationsById.TryGetValue("TestItem.Bird.Eagle", out source));
 			Assert.AreEqual("Fish-eating bird", source);
+			Assert.IsTrue(endoc.File.Body.TranslationsById.TryGetValue("TestItem.SettingsProtection.CtrlShiftHint", out source));
+			Assert.AreEqual("The button will show up when you hold down the Ctrl and Shift keys together.", source);
+			Assert.IsTrue(endoc.File.Body.TranslationsById.TryGetValue("TestItem.SettingsProtection.LauncherButtonLabel", out source));
+			Assert.AreEqual("Settings Protection...", source);
+			Assert.IsTrue(endoc.File.Body.TranslationsById.TryGetValue("TestItem.SettingsProtection.NormallyHiddenCheckbox", out source));
+			Assert.AreEqual("Hide the button that opens settings.", source);
+			Assert.IsTrue(endoc.File.Body.TranslationsById.TryGetValue("TestItem.SettingsProtection.PasswordDialog.FactoryPassword", out source));
+			Assert.AreEqual("Factory Password", source);
+			Assert.IsTrue(endoc.File.Body.ApprovalsById.TryGetValue("TestItem.Bird.Crow", out approved));
+			Assert.IsTrue(approved);
+			Assert.IsTrue(endoc.File.Body.ApprovalsById.TryGetValue("TestItem.Bird.Raven", out approved));
+			Assert.IsTrue(approved);
+			Assert.IsTrue(endoc.File.Body.ApprovalsById.TryGetValue("TestItem.Chicken.Rooster", out approved));
+			Assert.IsTrue(approved);
+			Assert.IsTrue(endoc.File.Body.ApprovalsById.TryGetValue("TestItem.Bird.Eagle", out approved));
+			Assert.IsTrue(approved);
+			Assert.IsTrue(endoc.File.Body.ApprovalsById.TryGetValue("TestItem.SettingsProtection.CtrlShiftHint", out approved));
+			Assert.IsTrue(approved);
+			Assert.IsTrue(endoc.File.Body.ApprovalsById.TryGetValue("TestItem.SettingsProtection.LauncherButtonLabel", out approved));
+			Assert.IsTrue(approved);
+			Assert.IsTrue(endoc.File.Body.ApprovalsById.TryGetValue("TestItem.SettingsProtection.NormallyHiddenCheckbox", out approved));
+			Assert.IsTrue(approved);
+			Assert.IsTrue(endoc.File.Body.ApprovalsById.TryGetValue("TestItem.SettingsProtection.PasswordDialog.FactoryPassword", out approved));
+			Assert.IsTrue(approved);
 
 			var frfile = Path.Combine(_testFolder, "Test.fr.xlf");
 			var frdoc = XLiffDocument.Read(frfile);
@@ -93,18 +118,35 @@ namespace L10NSharp.Tests
 			Assert.AreEqual("C'est un poulet", source);
 			Assert.IsTrue(frdoc.File.Body.TranslationsById.TryGetValue("TestItem.Bird.Eagle", out source));
 			Assert.AreEqual("Un oiseau qui mange des poissons", source);
+			Assert.IsTrue(frdoc.File.Body.ApprovalsById.TryGetValue("TestItem.Bird.Crow", out approved));
+			Assert.IsFalse(approved);
+			Assert.IsTrue(frdoc.File.Body.ApprovalsById.TryGetValue("TestItem.Bird.Raven", out approved));
+			Assert.IsFalse(approved);
+			Assert.IsTrue(frdoc.File.Body.ApprovalsById.TryGetValue("TestItem.Chicken.Rooster", out approved));
+			Assert.IsFalse(approved);
+			Assert.IsTrue(frdoc.File.Body.ApprovalsById.TryGetValue("TestItem.Bird.Eagle", out approved));
+			Assert.IsFalse(approved);
 
 			var esfile = Path.Combine(_testFolder, "Test.es.xlf");
 			var esdoc = XLiffDocument.Read(esfile);
 			Assert.AreEqual(4, esdoc.StringCount);
-			Assert.IsTrue(esdoc.File.Body.TranslationsById.TryGetValue("SettingsProtection.CtrlShiftHint", out source));
+			Assert.IsTrue(esdoc.File.Body.TranslationsById.TryGetValue("TestItem.SettingsProtection.CtrlShiftHint", out source));
 			Assert.AreEqual("El botón se mostrará cuando se mantengan presionadas juntas las teclas Ctrl y Mayús.", source);
-			Assert.IsTrue(esdoc.File.Body.TranslationsById.TryGetValue("SettingsProtection.LauncherButtonLabel", out source));
+			Assert.IsTrue(esdoc.File.Body.TranslationsById.TryGetValue("TestItem.SettingsProtection.LauncherButtonLabel", out source));
 			Assert.AreEqual("Protección de configuraciones...", source);
-			Assert.IsTrue(esdoc.File.Body.TranslationsById.TryGetValue("SettingsProtection.NormallyHiddenCheckbox", out source));
+			Assert.IsTrue(esdoc.File.Body.TranslationsById.TryGetValue("TestItem.SettingsProtection.NormallyHiddenCheckbox", out source));
 			Assert.AreEqual("Ocultar el botón que abre la configuración.", source);
-			Assert.IsTrue(esdoc.File.Body.TranslationsById.TryGetValue("SettingsProtection.PasswordDialog.FactoryPassword", out source));
-			Assert.AreEqual("Factory Password", source);	// note it's stored and returned even though marked as needing translation
+			// note the next string is not stored and returned since it's marked as needing translation
+			Assert.IsFalse(esdoc.File.Body.TranslationsById.TryGetValue("TestItem.SettingsProtection.PasswordDialog.FactoryPassword", out source));
+
+			Assert.IsTrue(esdoc.File.Body.ApprovalsById.TryGetValue("TestItem.SettingsProtection.CtrlShiftHint", out approved));
+			Assert.IsTrue(approved);
+			Assert.IsTrue(esdoc.File.Body.ApprovalsById.TryGetValue("TestItem.SettingsProtection.LauncherButtonLabel", out approved));
+			Assert.IsFalse(approved);
+			Assert.IsTrue(esdoc.File.Body.ApprovalsById.TryGetValue("TestItem.SettingsProtection.NormallyHiddenCheckbox", out approved));
+			Assert.IsTrue(approved);
+			// note the next string is not stored and returned since it's marked as needing translation
+			Assert.IsFalse(esdoc.File.Body.ApprovalsById.TryGetValue("TestItem.SettingsProtection.PasswordDialog.FactoryPassword", out approved));
 		}
 
 		[Test]
@@ -112,38 +154,94 @@ namespace L10NSharp.Tests
 		{
 			try
 			{
-				LocalizationManager.ReturnOnlyApprovedStrings = true;
-				var enfile = Path.Combine(_testFolder, "Test.en.xlf");
-				var endoc = XLiffDocument.Read(enfile);
-				string source;
-				Assert.IsTrue(endoc.File.Body.TranslationsById.TryGetValue("TestItem.Bird.Crow", out source));
-				Assert.AreEqual("It's a crow", source);
-				Assert.IsTrue(endoc.File.Body.TranslationsById.TryGetValue("TestItem.Bird.Raven", out source));
-				Assert.AreEqual("It's not a crow", source);
-				Assert.IsTrue(endoc.File.Body.TranslationsById.TryGetValue("TestItem.Chicken.Rooster", out source));
-				Assert.AreEqual("It's a chicken", source);
-				Assert.IsTrue(endoc.File.Body.TranslationsById.TryGetValue("TestItem.Bird.Eagle", out source));
-				Assert.AreEqual("Fish-eating bird", source);
+				LocalizationManager.UseLanguageCodeFolders = false;
+				LocalizationManager.ReturnOnlyApprovedStrings = false;       // change after loading to test behavior
+				var l10nMgr = LocalizationManager.Create(TranslationMemory.XLiff, "en", "Test", "Test", "1.0.0.0", _testFolder, null, null, "fake@wherever.org", "TestItem");
 
-				var frfile = Path.Combine(_testFolder, "Test.fr.xlf");
-				var frdoc = XLiffDocument.Read(frfile);
-				Assert.IsFalse(frdoc.File.Body.TranslationsById.TryGetValue("TestItem.Bird.Crow", out source));
-				Assert.IsFalse(frdoc.File.Body.TranslationsById.TryGetValue("TestItem.Bird.Raven", out source));
-				Assert.IsFalse(frdoc.File.Body.TranslationsById.TryGetValue("TestItem.Chicken.Rooster", out source));
-				Assert.IsFalse(frdoc.File.Body.TranslationsById.TryGetValue("TestItem.Bird.Eagle", out source));
+				LocalizationManager.ReturnOnlyApprovedStrings = true;       // SUT (changed after loading)
 
-				var esfile = Path.Combine(_testFolder, "Test.es.xlf");
-				var esdoc = XLiffDocument.Read(esfile);
-				Assert.IsTrue(esdoc.File.Body.TranslationsById.TryGetValue("SettingsProtection.CtrlShiftHint", out source));
-				Assert.AreEqual("El botón se mostrará cuando se mantengan presionadas juntas las teclas Ctrl y Mayús.", source);
-				Assert.IsFalse(esdoc.File.Body.TranslationsById.TryGetValue("SettingsProtection.LauncherButtonLabel", out source));
-				Assert.IsTrue(esdoc.File.Body.TranslationsById.TryGetValue("SettingsProtection.NormallyHiddenCheckbox", out source));
-				Assert.AreEqual("Ocultar el botón que abre la configuración.", source);
-				Assert.IsFalse(esdoc.File.Body.TranslationsById.TryGetValue("SettingsProtection.PasswordDialog.FactoryPassword", out source));
+				LocalizationManager.SetUILanguage("en", true);
+				var text = l10nMgr.GetLocalizedString("TestItem.Bird.Crow", "It's a crow");
+				Assert.AreEqual("It's a crow", text);
+				text = l10nMgr.GetLocalizedString("TestItem.Bird.Raven", "It's a raven, not a crow");	// revised string
+				Assert.AreEqual("It's a raven, not a crow", text);
+				text = l10nMgr.GetLocalizedString("TestItem.Chicken.Rooster", "It's a chicken");
+				Assert.AreEqual("It's a chicken", text);
+				text = l10nMgr.GetLocalizedString("TestItem.Bird.Eagle", "Fish-eating bird");
+				Assert.AreEqual("Fish-eating bird", text);
+
+				LocalizationManager.SetUILanguage("fr", true);
+				text = l10nMgr.GetLocalizedString("TestItem.Bird.Crow", "not there");
+				Assert.AreEqual("not there", text);
+				text = l10nMgr.GetLocalizedString("TestItem.Bird.Raven", "not there");
+				Assert.AreEqual("not there", text);
+				text = l10nMgr.GetLocalizedString("TestItem.Chicken.Rooster", "not there");
+				Assert.AreEqual("not there", text);
+				text = l10nMgr.GetLocalizedString("TestItem.Bird.Eagle", "not there");
+				Assert.AreEqual("not there", text);
+
+				LocalizationManager.SetUILanguage("es-ES", true);
+				text = l10nMgr.GetLocalizedString("TestItem.SettingsProtection.CtrlShiftHint", "not there");
+				Assert.AreEqual("El botón se mostrará cuando se mantengan presionadas juntas las teclas Ctrl y Mayús.", text);
+				text = l10nMgr.GetLocalizedString("TestItem.SettingsProtection.LauncherButtonLabel", "not there");
+				Assert.AreEqual("not there", text);
+				text = l10nMgr.GetLocalizedString("TestItem.SettingsProtection.NormallyHiddenCheckbox", "not there");
+				Assert.AreEqual("Ocultar el botón que abre la configuración.", text);
+				text = l10nMgr.GetLocalizedString("TestItem.SettingsProtection.PasswordDialog.FactoryPassword", "not there");
+				Assert.AreEqual("not there", text);
 			}
 			finally
 			{
-				LocalizationManager.ReturnOnlyApprovedStrings = false;	// restore default for other tests
+				LocalizationManager.ReturnOnlyApprovedStrings = false;  // restore default for other tests
+				LocalizationManager.SetUILanguage(LocalizationManager.kDefaultLang, true);
+			}
+		}
+
+		[Test]
+		public void TestReturningUnApprovedStrings()
+		{
+			try
+			{
+				LocalizationManager.UseLanguageCodeFolders = false;
+				LocalizationManager.ReturnOnlyApprovedStrings = true;  // change after loading to text code behavior
+				var l10nMgr = LocalizationManager.Create(TranslationMemory.XLiff, "en", "Test", "Test", "1.0.0.0", _testFolder, null, null, "fake@wherever.org", "TestItem");
+
+				LocalizationManager.ReturnOnlyApprovedStrings = false;  // SUT (changed after loading)
+
+				LocalizationManager.SetUILanguage("en", true);
+				var text = l10nMgr.GetLocalizedString("TestItem.Bird.Crow", "It's a crow");
+				Assert.AreEqual("It's a crow", text);
+				text = l10nMgr.GetLocalizedString("TestItem.Bird.Raven", "It's a raven, not a crow");   // revised string
+				Assert.AreEqual("It's a raven, not a crow", text);
+				text = l10nMgr.GetLocalizedString("TestItem.Chicken.Rooster", "It's a chicken");
+				Assert.AreEqual("It's a chicken", text);
+				text = l10nMgr.GetLocalizedString("TestItem.Bird.Eagle", "Fish-eating bird");
+				Assert.AreEqual("Fish-eating bird", text);
+
+				LocalizationManager.SetUILanguage("fr", true);
+				text = l10nMgr.GetLocalizedString("TestItem.Bird.Crow", "not there");
+				Assert.AreEqual("C'est un corbeau", text);
+				text = l10nMgr.GetLocalizedString("TestItem.Bird.Raven", "not there");
+				Assert.AreEqual("Ce n'est pas un corbeau", text);
+				text = l10nMgr.GetLocalizedString("TestItem.Chicken.Rooster", "not there");
+				Assert.AreEqual("C'est un poulet", text);
+				text = l10nMgr.GetLocalizedString("TestItem.Bird.Eagle", "not there");
+				Assert.AreEqual("Un oiseau qui mange des poissons", text);
+
+				LocalizationManager.SetUILanguage("es-ES", true);
+				text = l10nMgr.GetLocalizedString("TestItem.SettingsProtection.CtrlShiftHint", "not there");
+				Assert.AreEqual("El botón se mostrará cuando se mantengan presionadas juntas las teclas Ctrl y Mayús.", text);
+				text = l10nMgr.GetLocalizedString("TestItem.SettingsProtection.LauncherButtonLabel", "not there");
+				Assert.AreEqual("Protección de configuraciones...", text);
+				text = l10nMgr.GetLocalizedString("TestItem.SettingsProtection.NormallyHiddenCheckbox", "not there");
+				Assert.AreEqual("Ocultar el botón que abre la configuración.", text);
+				text = l10nMgr.GetLocalizedString("TestItem.SettingsProtection.PasswordDialog.FactoryPassword", "not there");
+				Assert.AreEqual("Factory Password", text);  // original (xliff) English is fallback for Spanish
+			}
+			finally
+			{
+				LocalizationManager.ReturnOnlyApprovedStrings = false;  // restore default for other tests
+				LocalizationManager.SetUILanguage(LocalizationManager.kDefaultLang, true);
 			}
 		}
 


### PR DESCRIPTION
This supports optionally viewing unapproved translations as requested by
https://issues.bloomlibrary.org/youtrack/issue/BL-7281.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/64)
<!-- Reviewable:end -->
