### PR TITLE
Added version of LocalizationManager.Create with param to allow additional GetString methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Add `ExtractXliff` tool as nuget package
 - Add `CheckOrFixXliff` tool as nuget package
+- Added version of LocalizationManager.Create to allow "custom" localization methods
 
 ## [4.0.3] - 2020-01-21
 

--- a/src/ExtractXliff/Program.cs
+++ b/src/ExtractXliff/Program.cs
@@ -1,9 +1,8 @@
-// Copyright (c) 2017 SIL International
+// Copyright (c) 2020 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using L10NSharp;
 using L10NSharp.CodeReader;
@@ -78,7 +77,7 @@ namespace ExtractXliff
 
 			// Scan the input assemblies for localizable strings.
 			var extractor = new StringExtractor<XLiffDocument> { ExternalAssembliesToScan = assemblies.ToArray() };
-			var localizedStrings = extractor.DoExtractingWork(null, _namespaces.ToArray(), null);
+			var localizedStrings = extractor.DoExtractingWork(_namespaces.ToArray(), null);
 
 			// The arguments to this constructor don't really matter much as they're used internally by
 			// L10NSharp for reasons that may not percolate out to xliff.  We just need a LocalizationManagerInternal

--- a/src/ExtractXliff/Program.cs
+++ b/src/ExtractXliff/Program.cs
@@ -78,7 +78,7 @@ namespace ExtractXliff
 
 			// Scan the input assemblies for localizable strings.
 			var extractor = new StringExtractor<XLiffDocument> { ExternalAssembliesToScan = assemblies.ToArray() };
-			var localizedStrings = extractor.DoExtractingWork(_namespaces.ToArray(), null);
+			var localizedStrings = extractor.DoExtractingWork(null, _namespaces.ToArray(), null);
 
 			// The arguments to this constructor don't really matter much as they're used internally by
 			// L10NSharp for reasons that may not percolate out to xliff.  We just need a LocalizationManagerInternal

--- a/src/L10NSharp/CodeReader/StringExtractor.cs
+++ b/src/L10NSharp/CodeReader/StringExtractor.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2020 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -28,6 +31,13 @@ namespace L10NSharp.CodeReader
 
 		/// ------------------------------------------------------------------------------------
 		public IEnumerable<LocalizingInfo> DoExtractingWork(
+			string[] namespaceBeginnings, BackgroundWorker worker)
+		{
+			return DoExtractingWork(null, namespaceBeginnings, worker);
+		}
+
+		/// ------------------------------------------------------------------------------------
+		public IEnumerable<LocalizingInfo> DoExtractingWork(
 			IEnumerable<MethodInfo> additionalLocalizationMethods,
 			string[] namespaceBeginnings, BackgroundWorker worker)
 		{
@@ -39,7 +49,6 @@ namespace L10NSharp.CodeReader
 				.Where(m => m.Name == "Localize"))
 				.Union(additionalLocalizationMethods ?? new MethodInfo[0])
 				.ToArray();
-
 
 			_getStringCallsInfo = new List<LocalizingInfo>();
 			_extenderInfo = new Dictionary<string, LocalizingInfo>();

--- a/src/L10NSharp/LocalizationManager.cs
+++ b/src/L10NSharp/LocalizationManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Globalization;
+using System.Reflection;
 using System.Threading;
 using System.Windows.Forms;
 using L10NSharp.TMXUtils;
@@ -94,6 +95,57 @@ namespace L10NSharp
 			string relativeSettingPathForLocalizationFolder,
 			Icon applicationIcon, string emailForSubmissions, params string[] namespaceBeginnings)
 		{
+			return Create(kind, desiredUiLangId,
+				appId, appName, appVersion, directoryOfInstalledFiles,
+				relativeSettingPathForLocalizationFolder,
+				applicationIcon, emailForSubmissions,
+				null, namespaceBeginnings);
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Creates a new instance of a localization manager for the specified application id.
+		/// If a localization manager has already been created for the specified id, then
+		/// that is returned.
+		/// </summary>
+		/// <param name="kind">Translation memory type to use</param>
+		/// <param name="desiredUiLangId">The language code of the desired UI language. If
+		/// there are no translations for that ID, a message is displayed and the UI language
+		/// falls back to the default.</param>
+		/// <param name="appId">The application Id (e.g. 'Pa' for Phonology Assistant).
+		/// This should be a unique name that identifies the manager for an assembly or
+		/// application.</param>
+		/// <param name="appName">The application's name. This will appear to the user
+		/// in the localization dialog box as a parent item in the tree.</param>
+		/// <param name="appVersion"></param>
+		/// <param name="directoryOfInstalledFiles">The full folder path of the original Xliff/TMX
+		/// files installed with the application.</param>
+		/// <param name="relativeSettingPathForLocalizationFolder">The path, relative to
+		/// %appdata%, where your application stores user settings (e.g., "SIL\SayMore").
+		/// A folder named "localizations" will be created there.</param>
+		/// <param name="applicationIcon"> </param>
+		/// <param name="emailForSubmissions">This will be used in UI that helps the translator
+		/// know what to do with their work</param>
+		/// <param name="additionalLocalizationMethods">MethodInfo objects representing
+		/// additional methods that should be regarded as calls to get localizations. If the method
+		/// is named "Localize", its signature will be parsed as if it were an extension method
+		/// where the first parameter is the English string and the second parameter is the ID.
+		/// Otherwise, it will be treated like a GetString method where the first parameter is
+		/// the ID and the second parameter is the English string. In both cases, the following
+		/// additional optional parameters are permitted in this order: comment, tootip, shortcut
+		/// keys. All parameters must be of type string.</param>
+		/// <param name="namespaceBeginnings">A list of namespace beginnings indicating
+		/// what types to scan for localized string calls. For example, to only scan
+		/// types found in Pa.exe and assuming all types in that assembly begin with
+		/// 'Pa', then this value would only contain the string 'Pa'.</param>
+		/// ------------------------------------------------------------------------------------
+		public static ILocalizationManager Create(TranslationMemory kind, string desiredUiLangId,
+			string appId, string appName, string appVersion, string directoryOfInstalledFiles,
+			string relativeSettingPathForLocalizationFolder,
+			Icon applicationIcon, string emailForSubmissions,
+			IEnumerable<MethodInfo> additionalLocalizationMethods,
+			params string[] namespaceBeginnings)
+		{
 			TranslationMemoryKind = kind;
 			EmailForSubmissions = emailForSubmissions;
 			switch (kind)
@@ -102,11 +154,13 @@ namespace L10NSharp
 					return LocalizationManagerInternal<TMXDocument>.CreateTmx(desiredUiLangId,
 						appId, appName, appVersion, directoryOfInstalledFiles,
 						relativeSettingPathForLocalizationFolder, applicationIcon,
+						additionalLocalizationMethods,
 						namespaceBeginnings);
 				case TranslationMemory.XLiff:
 					return LocalizationManagerInternal<XLiffDocument>.CreateXliff(desiredUiLangId,
 						appId, appName, appVersion, directoryOfInstalledFiles,
 						relativeSettingPathForLocalizationFolder, applicationIcon,
+						additionalLocalizationMethods,
 						namespaceBeginnings);
 				default:
 					throw new ArgumentException($"Unknown translation memory kind {kind}",

--- a/src/L10NSharp/LocalizationManager.cs
+++ b/src/L10NSharp/LocalizationManager.cs
@@ -128,12 +128,13 @@ namespace L10NSharp
 		/// know what to do with their work</param>
 		/// <param name="additionalLocalizationMethods">MethodInfo objects representing
 		/// additional methods that should be regarded as calls to get localizations. If the method
-		/// is named "Localize", its signature will be parsed as if it were an extension method
-		/// where the first parameter is the English string and the second parameter is the ID.
-		/// Otherwise, it will be treated like a GetString method where the first parameter is
-		/// the ID and the second parameter is the English string. In both cases, the following
-		/// additional optional parameters are permitted in this order: comment, tootip, shortcut
-		/// keys. All parameters must be of type string.</param>
+		/// is named "Localize", the extractor will attempt to parse its signature as an extension
+		/// method with the parameters (this string s, string separateId="", string comment="").
+		/// Otherwise, it will be treated like a L10nSharp GetString method if its signature
+		/// matches one of the following: (string stringId, string englishText),
+		/// (string stringId, string englishText, string comment), or
+		/// (string stringId, string englishText, string comment, string englishToolTipText,
+		/// string englishShortcutKey, IComponent component).</param>
 		/// <param name="namespaceBeginnings">A list of namespace beginnings indicating
 		/// what types to scan for localized string calls. For example, to only scan
 		/// types found in Pa.exe and assuming all types in that assembly begin with

--- a/src/L10NSharp/LocalizationManagerInternal.cs
+++ b/src/L10NSharp/LocalizationManagerInternal.cs
@@ -8,6 +8,7 @@ using System.Drawing;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Windows.Forms;
 using L10NSharp.TMXUtils;
 using L10NSharp.UI;
@@ -97,6 +98,14 @@ namespace L10NSharp
 		/// %appdata%, where your application stores user settings (e.g., "SIL\SayMore").
 		/// A folder named "localizations" will be created there.</param>
 		/// <param name="applicationIcon"> </param>
+		/// <param name="additionalLocalizationMethods">MethodInfo objects representing
+		/// additional methods that should be regarded as calls to get localizations. If the method
+		/// is named "Localize", its signature will be parsed as if it were an extension method
+		/// where the first parameter is the English string and the second parameter is the ID.
+		/// Otherwise, it will be treated like a GetString method where the first parameter is
+		/// the ID and the second parameter is the English string. In both cases, the following
+		/// additional optional parameters are permitted in this order: comment, tootip, shortcut
+		/// keys. All parameters must be of type string.</param>
 		/// <param name="namespaceBeginnings">A list of namespace beginnings indicating
 		/// what types to scan for localized string calls. For example, to only scan
 		/// types found in Pa.exe and assuming all types in that assembly begin with
@@ -105,7 +114,8 @@ namespace L10NSharp
 		public static ILocalizationManager CreateTmx(string desiredUiLangId, string appId,
 			string appName, string appVersion, string directoryOfInstalledTmxFiles,
 			string relativeSettingPathForLocalizationFolder,
-			Icon applicationIcon, params string[] namespaceBeginnings)
+			Icon applicationIcon, IEnumerable<MethodInfo> additionalLocalizationMethods,
+			params string[] namespaceBeginnings)
 		{
 			return Create(desiredUiLangId, appId, appName,
 				relativeSettingPathForLocalizationFolder, applicationIcon,
@@ -113,6 +123,7 @@ namespace L10NSharp
 					(ILocalizationManagerInternal<T>) new TMXLocalizationManager(appId, appName,
 						appVersion, directoryOfInstalledTmxFiles,
 						directoryOfWritableTmxFiles, directoryOfWritableTmxFiles,
+						additionalLocalizationMethods,
 						namespaceBeginnings));
 		}
 
@@ -137,6 +148,14 @@ namespace L10NSharp
 		/// %appdata%, where your application stores user settings (e.g., "SIL\SayMore").
 		/// A folder named "localizations" will be created there.</param>
 		/// <param name="applicationIcon"> </param>
+		/// <param name="additionalLocalizationMethods">MethodInfo objects representing
+		/// additional methods that should be regarded as calls to get localizations. If the method
+		/// is named "Localize", its signature will be parsed as if it were an extension method
+		/// where the first parameter is the English string and the second parameter is the ID.
+		/// Otherwise, it will be treated like a GetString method where the first parameter is
+		/// the ID and the second parameter is the English string. In both cases, the following
+		/// additional optional parameters are permitted in this order: comment, tootip, shortcut
+		/// keys. All parameters must be of type string.</param>
 		/// <param name="namespaceBeginnings">A list of namespace beginnings indicating
 		/// what types to scan for localized string calls. For example, to only scan
 		/// types found in Pa.exe and assuming all types in that assembly begin with
@@ -145,7 +164,9 @@ namespace L10NSharp
 		public static ILocalizationManager CreateXliff(string desiredUiLangId, string appId,
 			string appName, string appVersion, string directoryOfInstalledXliffFiles,
 			string relativeSettingPathForLocalizationFolder,
-			Icon applicationIcon, params string[] namespaceBeginnings)
+			Icon applicationIcon,
+			IEnumerable<MethodInfo> additionalLocalizationMethods,
+			params string[] namespaceBeginnings)
 		{
 			return Create(desiredUiLangId, appId, appName,
 				relativeSettingPathForLocalizationFolder, applicationIcon,
@@ -153,6 +174,7 @@ namespace L10NSharp
 					(ILocalizationManagerInternal<T>) new XLiffLocalizationManager(appId, appName,
 						appVersion, directoryOfInstalledXliffFiles,
 						directoryOfWritableXliffFiles, directoryOfWritableXliffFiles,
+						additionalLocalizationMethods,
 						namespaceBeginnings));
 		}
 

--- a/src/L10NSharp/LocalizationManagerInternal.cs
+++ b/src/L10NSharp/LocalizationManagerInternal.cs
@@ -100,12 +100,13 @@ namespace L10NSharp
 		/// <param name="applicationIcon"> </param>
 		/// <param name="additionalLocalizationMethods">MethodInfo objects representing
 		/// additional methods that should be regarded as calls to get localizations. If the method
-		/// is named "Localize", its signature will be parsed as if it were an extension method
-		/// where the first parameter is the English string and the second parameter is the ID.
-		/// Otherwise, it will be treated like a GetString method where the first parameter is
-		/// the ID and the second parameter is the English string. In both cases, the following
-		/// additional optional parameters are permitted in this order: comment, tootip, shortcut
-		/// keys. All parameters must be of type string.</param>
+		/// is named "Localize", the extractor will attempt to parse its signature as an extension
+		/// method with the parameters (this string s, string separateId="", string comment="").
+		/// Otherwise, it will be treated like a L10nSharp GetString method if its signature
+		/// matches one of the following: (string stringId, string englishText),
+		/// (string stringId, string englishText, string comment), or
+		/// (string stringId, string englishText, string comment, string englishToolTipText,
+		/// string englishShortcutKey, IComponent component).</param>
 		/// <param name="namespaceBeginnings">A list of namespace beginnings indicating
 		/// what types to scan for localized string calls. For example, to only scan
 		/// types found in Pa.exe and assuming all types in that assembly begin with
@@ -150,12 +151,13 @@ namespace L10NSharp
 		/// <param name="applicationIcon"> </param>
 		/// <param name="additionalLocalizationMethods">MethodInfo objects representing
 		/// additional methods that should be regarded as calls to get localizations. If the method
-		/// is named "Localize", its signature will be parsed as if it were an extension method
-		/// where the first parameter is the English string and the second parameter is the ID.
-		/// Otherwise, it will be treated like a GetString method where the first parameter is
-		/// the ID and the second parameter is the English string. In both cases, the following
-		/// additional optional parameters are permitted in this order: comment, tootip, shortcut
-		/// keys. All parameters must be of type string.</param>
+		/// is named "Localize", the extractor will attempt to parse its signature as an extension
+		/// method with the parameters (this string s, string separateId="", string comment="").
+		/// Otherwise, it will be treated like a L10nSharp GetString method if its signature
+		/// matches one of the following: (string stringId, string englishText),
+		/// (string stringId, string englishText, string comment), or
+		/// (string stringId, string englishText, string comment, string englishToolTipText,
+		/// string englishShortcutKey, IComponent component).</param>
 		/// <param name="namespaceBeginnings">A list of namespace beginnings indicating
 		/// what types to scan for localized string calls. For example, to only scan
 		/// types found in Pa.exe and assuming all types in that assembly begin with

--- a/src/L10NSharp/TMXUtils/TMXLocalizationManager.cs
+++ b/src/L10NSharp/TMXUtils/TMXLocalizationManager.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Security;
 using System.Security.Permissions;
 using System.Text.RegularExpressions;
@@ -83,7 +84,9 @@ namespace L10NSharp.TMXUtils
 		/// ------------------------------------------------------------------------------------
 		internal TMXLocalizationManager(string appId, string appName, string appVersion,
 			string directoryOfInstalledTmxFiles, string directoryForGeneratedDefaultTmxFile,
-			string directoryOfUserModifiedTmxFiles, params string[] namespaceBeginnings)
+			string directoryOfUserModifiedTmxFiles,
+			IEnumerable<MethodInfo> additionalLocalizationMethods,
+			params string[] namespaceBeginnings)
 		{
 			// Test for a pathological case of bad install
 			if (!Directory.Exists(directoryOfInstalledTmxFiles))
@@ -100,7 +103,7 @@ namespace L10NSharp.TMXUtils
 			NamespaceBeginnings = namespaceBeginnings;
 			CollectUpNewStringsDiscoveredDynamically = true;
 
-			CreateOrUpdateDefaultTmxFileIfNecessary(namespaceBeginnings);
+			CreateOrUpdateDefaultTmxFileIfNecessary(additionalLocalizationMethods, namespaceBeginnings);
 
 			_customTmxFileFolder = directoryOfUserModifiedTmxFiles;
 			if (string.IsNullOrEmpty(_customTmxFileFolder))
@@ -138,7 +141,7 @@ namespace L10NSharp.TMXUtils
 		}
 
 		/// ------------------------------------------------------------------------------------
-		private void CreateOrUpdateDefaultTmxFileIfNecessary(params string[] namespaceBeginnings)
+		private void CreateOrUpdateDefaultTmxFileIfNecessary(IEnumerable<MethodInfo> additionalLocalizationMethods, params string[] namespaceBeginnings)
 		{
 			// Make sure the folder exists.
 			var dir = Path.GetDirectoryName(DefaultStringFilePath);
@@ -174,7 +177,7 @@ namespace L10NSharp.TMXUtils
 			tmxDoc.Header.SetPropValue(LocalizationManager.kAppVersionPropTag, AppVersion);
 			var tuUpdater = new TMXTransUnitUpdater(tmxDoc);
 
-			using (var dlg = new InitializationProgressDlg<TMXDocument>(Name, ApplicationIcon, namespaceBeginnings))
+			using (var dlg = new InitializationProgressDlg<TMXDocument>(Name, ApplicationIcon, additionalLocalizationMethods, namespaceBeginnings))
 			{
 				dlg.ShowDialog();
 				if (dlg.ExtractedInfo != null)

--- a/src/L10NSharp/UI/InitializationProgressDlg.cs
+++ b/src/L10NSharp/UI/InitializationProgressDlg.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
+using System.Reflection;
 using L10NSharp.CodeReader;
 
 namespace L10NSharp.UI
@@ -12,20 +13,23 @@ namespace L10NSharp.UI
 		public IEnumerable<LocalizingInfo> ExtractedInfo { get; private set; }
 
 		/// ------------------------------------------------------------------------------------
-		public InitializationProgressDlg(string appName, params string[] namespaceBeginnings):
-			base(appName, namespaceBeginnings)
+		public InitializationProgressDlg(string appName, IEnumerable<MethodInfo> additionalLocalizationMethods,
+			params string[] namespaceBeginnings):
+			base(appName, additionalLocalizationMethods, namespaceBeginnings)
 		{
 		}
 
 		public InitializationProgressDlg(string appName, Icon formIcon,
-			params string[] namespaceBeginnings) : base(appName, formIcon, namespaceBeginnings)
+			IEnumerable<MethodInfo> additionalLocalizationMethods,
+			params string[] namespaceBeginnings) :
+			base(appName, formIcon, additionalLocalizationMethods, namespaceBeginnings)
 		{
 		}
 
 		protected override void backgroundWorker_DoWork(object sender, System.ComponentModel.DoWorkEventArgs e)
 		{
 			var extractor = new StringExtractor<T>();
-			e.Result = extractor.DoExtractingWork(_namespaceBeginnings, sender as BackgroundWorker);
+			e.Result = extractor.DoExtractingWork(_additionalLocalizationMethods, _namespaceBeginnings, sender as BackgroundWorker);
 		}
 
 		protected override void backgroundWorker_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)

--- a/src/L10NSharp/UI/InitializationProgressDlgBase.cs
+++ b/src/L10NSharp/UI/InitializationProgressDlgBase.cs
@@ -1,28 +1,33 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Drawing;
+using System.Reflection;
 using System.Windows.Forms;
-using L10NSharp.CodeReader;
 
 namespace L10NSharp.UI
 {
 	/// ----------------------------------------------------------------------------------------
 	internal partial class InitializationProgressDlgBase : Form
 	{
+		protected readonly IEnumerable<MethodInfo> _additionalLocalizationMethods;
 		protected readonly string[] _namespaceBeginnings;
 		private readonly Icon _formIcon;
 
 		/// ------------------------------------------------------------------------------------
-		protected InitializationProgressDlgBase(string appName, params string[] namespaceBeginnings)
+		protected InitializationProgressDlgBase(string appName,
+			IEnumerable<MethodInfo> additionalLocalizationMethods,
+			params string[] namespaceBeginnings)
 		{
 			InitializeComponent();
 			Text = appName;
+			_additionalLocalizationMethods = additionalLocalizationMethods;
 			_namespaceBeginnings = namespaceBeginnings;
 		}
 
-		protected InitializationProgressDlgBase(string appName, Icon formIcon, params string[] namespaceBeginnings) : this(appName, namespaceBeginnings)
+		protected InitializationProgressDlgBase(string appName, Icon formIcon, 
+			IEnumerable<MethodInfo> additionalLocalizationMethods, params string[] namespaceBeginnings) :
+			this(appName, additionalLocalizationMethods, namespaceBeginnings)
 		{
 			_formIcon = formIcon;
 		}

--- a/src/L10NSharp/XLiffUtils/XLiffLocalizationManager.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffLocalizationManager.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Security;
 using System.Security.Permissions;
 using System.Text.RegularExpressions;
@@ -84,7 +85,9 @@ namespace L10NSharp.XLiffUtils
 		/// ------------------------------------------------------------------------------------
 		internal XLiffLocalizationManager(string appId, string appName, string appVersion,
 			string directoryOfInstalledXliffFiles, string directoryForGeneratedDefaultXliffFile,
-			string directoryOfUserModifiedXliffFiles, params string[] namespaceBeginnings)
+			string directoryOfUserModifiedXliffFiles,
+			IEnumerable<MethodInfo> additionalLocalizationMethods,
+			params string[] namespaceBeginnings)
 		{
 			// Test for a pathological case of bad install
 			if (!Directory.Exists(directoryOfInstalledXliffFiles))
@@ -102,7 +105,7 @@ namespace L10NSharp.XLiffUtils
 			NamespaceBeginnings = namespaceBeginnings;
 			CollectUpNewStringsDiscoveredDynamically = true;
 
-			CreateOrUpdateDefaultXliffFileIfNecessary(namespaceBeginnings);
+			CreateOrUpdateDefaultXliffFileIfNecessary(additionalLocalizationMethods, namespaceBeginnings);
 
 			_customXliffFileFolder = directoryOfUserModifiedXliffFiles;
 			if (string.IsNullOrEmpty(_customXliffFileFolder))
@@ -155,7 +158,9 @@ namespace L10NSharp.XLiffUtils
 		}
 
 		/// ------------------------------------------------------------------------------------
-		private void CreateOrUpdateDefaultXliffFileIfNecessary(params string[] namespaceBeginnings)
+		private void CreateOrUpdateDefaultXliffFileIfNecessary(
+			IEnumerable<MethodInfo> additionalLocalizationMethods,
+			params string[] namespaceBeginnings)
 		{
 			// Make sure the folder exists.
 			var dir = Path.GetDirectoryName(DefaultStringFilePath);
@@ -202,7 +207,7 @@ namespace L10NSharp.XLiffUtils
 			var stringCache = new XLiffLocalizedStringCache(this, false);
 
 			using (var dlg = new InitializationProgressDlg<XLiffDocument>(Name, _applicationIcon,
-				namespaceBeginnings))
+				additionalLocalizationMethods, namespaceBeginnings))
 			{
 				dlg.ShowDialog();
 				if (dlg.ExtractedInfo != null)

--- a/src/L10NSharpTests/ProxyLocalizationManager.cs
+++ b/src/L10NSharpTests/ProxyLocalizationManager.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2020 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+namespace L10NSharp.Tests
+{
+	class ProxyLocalizationManager
+	{
+		public static string MyOwnGetString(string id, string english, string comment)
+		{
+			return LocalizationManager.GetString(id, english, comment);
+		}
+	}
+}

--- a/src/L10NSharpTests/ProxyLocalizationManager.cs
+++ b/src/L10NSharpTests/ProxyLocalizationManager.cs
@@ -1,13 +1,35 @@
 // Copyright (c) 2020 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
+using System.ComponentModel;
+
 namespace L10NSharp.Tests
 {
-	class ProxyLocalizationManager
+	public class ProxyLocalizationManager
 	{
+		public static string MyOwnGetString(string id, string english)
+		{
+			return LocalizationManager.GetString(id, english);
+		}
+
 		public static string MyOwnGetString(string id, string english, string comment)
 		{
 			return LocalizationManager.GetString(id, english, comment);
+		}
+
+		public static string MyOwnGetString(string id, string english, string comment,
+			string englishToolTipText, string englishShortcutKey, IComponent component)
+		{
+			return LocalizationManager.GetString(id, english, comment, englishToolTipText,
+				englishShortcutKey, component);
+		}
+	}
+
+	public static class ProxyLocalizationStringExtensions
+	{
+		public static string Localize(this string s, string separateId="", string comment="")
+		{
+			return L10NStringExtensions.Localize(s, separateId, comment);
 		}
 	}
 }

--- a/src/L10NSharpTests/TMXLocalizationManagerTests.cs
+++ b/src/L10NSharpTests/TMXLocalizationManagerTests.cs
@@ -1,10 +1,11 @@
-// Copyright (c) 2019 SIL International
+// Copyright (c) 2020 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Xml.Linq;
 using L10NSharp.TMXUtils;
 using NUnit.Framework;
@@ -23,11 +24,12 @@ namespace L10NSharp.Tests
 		internal override ILocalizationManagerInternal<TMXDocument> CreateLocalizationManager(
 			string          appId,                               string appName, string appVersion, string directoryOfInstalledTmxFiles,
 			string          directoryForGeneratedDefaultTmxFile, string directoryOfUserModifiedXliffFiles,
+			IEnumerable<MethodInfo> additionalGetStringMethodInfo = null,
 			params string[] namespaceBeginnings)
 		{
 			return new TMXLocalizationManager(appId, appName, appVersion, directoryOfInstalledTmxFiles,
 				directoryForGeneratedDefaultTmxFile, directoryOfUserModifiedXliffFiles,
-				namespaceBeginnings);
+				additionalGetStringMethodInfo, namespaceBeginnings);
 		}
 
 		internal override ILocalizationManagerInternal<TMXDocument> CreateLocalizationManager(

--- a/src/L10NSharpTests/XLiffLocalizationManagerTests.cs
+++ b/src/L10NSharpTests/XLiffLocalizationManagerTests.cs
@@ -1,7 +1,8 @@
-// Copyright (c) 2019 SIL International
+// Copyright (c) 2020 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Collections.Generic;
+using System.Reflection;
 using System.Xml.Linq;
 using L10NSharp.XLiffUtils;
 using NUnit.Framework;
@@ -20,10 +21,11 @@ namespace L10NSharp.Tests
 		internal override ILocalizationManagerInternal<XLiffDocument> CreateLocalizationManager(
 			string          appId,                               string appName, string appVersion, string directoryOfInstalledTmxFiles,
 			string          directoryForGeneratedDefaultTmxFile, string directoryOfUserModifiedXliffFiles,
+			IEnumerable<MethodInfo> additionalGetStringMethodInfo = null,
 			params string[] namespaceBeginnings)
 		{
 			return new XLiffLocalizationManager(appId, appName, appVersion, directoryOfInstalledTmxFiles,
-				directoryForGeneratedDefaultTmxFile, directoryOfUserModifiedXliffFiles,
+				directoryForGeneratedDefaultTmxFile, directoryOfUserModifiedXliffFiles, additionalGetStringMethodInfo,
 				namespaceBeginnings);
 		}
 


### PR DESCRIPTION
This allows the client to specify additional localization methods when extracting from code. Useful, for example, when using SIL.Localizer to allow L10nSharp to be injected in code that does not depend on it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/75)
<!-- Reviewable:end -->
