### PR TITLE
PG-1365: Enhanced ExtractXliff tool to be able to specify additional methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add `ExtractXliff` tool as nuget package
 - Add `CheckOrFixXliff` tool as nuget package
 - Added version of LocalizationManager.Create to allow "custom" localization methods
+- Added -m switch to ExtractXliff command-line to allow caller to pass additional string-localization methods
 
 ## [4.0.3] - 2020-01-21
 

--- a/src/ExtractXliff/Program.cs
+++ b/src/ExtractXliff/Program.cs
@@ -84,6 +84,8 @@ namespace ExtractXliff
 					try
 					{
 						var type = asm.GetType(methodNameSpec.Item1 + "." + methodNameSpec.Item2);
+						if (type == null)
+							continue;
 						_additionalLocalizationMethods.AddRange(type
 							.GetMethods(BindingFlags.Static | BindingFlags.Public)
 							.Where(m => m.Name == methodNameSpec.Item3));
@@ -92,8 +94,10 @@ namespace ExtractXliff
 							Console.WriteLine($"Method {methodNameSpec.Item2}.{methodNameSpec.Item3} in {asm.GetName().FullName} will be treated as a localization method.");
 						_additionalLocalizationMethodNames.RemoveAt(index--);
 					}
-					catch
+					catch (Exception e)
 					{
+						if (_verbose)
+							Console.WriteLine("Error using reflection on {asm.GetName().FullName} to get type {methodNameSpec.Item2} or method {methodNameSpec.Item3}:" + e.Message);
 					}
 				}
 			}

--- a/src/ExtractXliff/Program.cs
+++ b/src/ExtractXliff/Program.cs
@@ -235,7 +235,15 @@ namespace ExtractXliff
 				if (args[i] == "--")
 					return false;
 
-				var match = Regex.Match(args[i], @"^(?<namespace>[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*)\.(?<class>[a-zA-Z_][a-zA-Z0-9_]*)\.(?<methodName>[a-zA-Z_][a-zA-Z0-9_]*)$");
+				const string validCSharpIdentifier = "[a-zA-Z_][a-zA-Z0-9_]*";
+				// Namespace can consist of any number of valid identifiers separated by periods.
+				// The second-to-last one will be the class name,
+				// and the last one will be the method name.
+				// Not that this does not support things like nested classes or generics (which
+				// are unlikely to be used for localized strings anyway).
+				var regexFullyQualifiedMethodName = new Regex(
+					$"^(?<namespace>{validCSharpIdentifier}(\\.{validCSharpIdentifier})*)\\.(?<class>{validCSharpIdentifier})\\.(?<methodName>{validCSharpIdentifier})$");
+				var match = regexFullyQualifiedMethodName.Match(args[i]);
 				if (match.Success)
 				{
 					_additionalLocalizationMethodNames.Add(


### PR DESCRIPTION
This allows us to harvest strings from non Windows.Forms assemblies in libpalaso (that can't reference L10nSharp) but that use the SIL.Localizer class as a proxy.