### PR TITLE
Create LocalizationManager using more specific locale if necessary

### DIFF
--- a/src/L10NSharp/LocalizationManagerInternal.cs
+++ b/src/L10NSharp/LocalizationManagerInternal.cs
@@ -59,7 +59,7 @@ namespace L10NSharp
 				desiredUiLangId = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
 			}
 
-			if (!DesiredUiCultureIsAvailable(desiredUiLangId))
+			if (!IsDesiredUiCultureAvailable(desiredUiLangId))
 			{
 				using (var dlg = new LanguageChoosingDialog(L10NCultureInfo.GetCultureInfo(desiredUiLangId), applicationIcon))
 				{
@@ -75,13 +75,16 @@ namespace L10NSharp
 			return lm;
 		}
 
-		private static bool DesiredUiCultureIsAvailable(string desiredUiLangId)
+		private static bool IsDesiredUiCultureAvailable(string desiredUiLangId)
 		{
 			var ci = L10NCultureInfo.GetCultureInfo(desiredUiLangId);
 			if (GetUILanguages(true).Contains(ci))
 				return true;
+			// If this fallback implementation seems strange, read the really long summary
+			// comment for the unit test:
+			// Create_PreferredUiLanguageIsGenericVariant_CreatesLocalizationManagerForSpecificVariant
 			return MapToExistingLanguage.TryGetValue(desiredUiLangId, out desiredUiLangId) &&
-				DesiredUiCultureIsAvailable(desiredUiLangId);
+				IsDesiredUiCultureAvailable(desiredUiLangId);
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/src/L10NSharp/LocalizationManagerInternal.cs
+++ b/src/L10NSharp/LocalizationManagerInternal.cs
@@ -59,10 +59,9 @@ namespace L10NSharp
 				desiredUiLangId = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
 			}
 
-			var ci = L10NCultureInfo.GetCultureInfo(desiredUiLangId);
-			if (!GetUILanguages(true).Contains(ci))
+			if (!DesiredUiCultureIsAvailable(desiredUiLangId))
 			{
-				using (var dlg = new LanguageChoosingDialog(ci, applicationIcon))
+				using (var dlg = new LanguageChoosingDialog(L10NCultureInfo.GetCultureInfo(desiredUiLangId), applicationIcon))
 				{
 					dlg.ShowDialog();
 					desiredUiLangId = dlg.SelectedLanguage;
@@ -76,6 +75,14 @@ namespace L10NSharp
 			return lm;
 		}
 
+		private static bool DesiredUiCultureIsAvailable(string desiredUiLangId)
+		{
+			var ci = L10NCultureInfo.GetCultureInfo(desiredUiLangId);
+			if (GetUILanguages(true).Contains(ci))
+				return true;
+			return MapToExistingLanguage.TryGetValue(desiredUiLangId, out desiredUiLangId) &&
+				DesiredUiCultureIsAvailable(desiredUiLangId);
+		}
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>

--- a/src/L10NSharpTests/LocalizationManagerXliffTests.cs
+++ b/src/L10NSharpTests/LocalizationManagerXliffTests.cs
@@ -6,18 +6,43 @@ using NUnit.Framework;
 
 namespace L10NSharp.Tests
 {
+	/// <summary>
+	/// Tests that only apply to Xliff, not TMX.
+	/// </summary>
 	[TestFixture]
 	public class LocalizationManagerXliffTests
 	{
-		[Test]
-		[Timeout(3000)] // This ensures that if the UI pops up, a developer will not have time to respond and the test won't hang.
-		public void Create_PreferredUiLanguageIsGenericVariant_CreatesLocalizationManagerForSpecificVariant()
+		/// <summary>
+		/// Indirectly, this is a test of LocalizationManagerInternal<XLiffDocument>.IsDesiredUiCultureAvailable,
+		/// which is called by its Create method. This test was written to ensure that a dialog is not displayed
+		/// incorrectly telling the user that the requested UI language is unavailable and asking them which UI
+		/// Language to use instead. If the implementation is incorrect, we don't want the test to hang because
+		/// of the dialog box but rather to fail. And of course, if the test is being run in an interactive
+		/// environment, we also don't the developer to interact with the dialog, which could give a false
+		/// success. So we set the timeout to 3 seconds, which seems to be long enough to let the test run
+		/// successfully but short enough to prevent a developer from interacting with it.
+		/// </summary>
+		/// <remarks>If you're wondering why this is XLIFF-only, it probably wouldn't have to be. The SUT runs
+		/// for both varieties of LM. However, in practice, there will probably never be a case where this
+		/// behavior is needed for TMX. It was written to make it so that apps that used to use TMX, which
+		/// typically used the "generic" two-letter language ID will work seamlessly when the app starts
+		/// using XLIFF, because crowdin.com seems to insist on using country-specific variants for some
+		/// languages. (For some reason, it does allow French to just be "fr".)  </remarks>
+		[TestCase("es", "es-ES")]
+		[TestCase("pt", "pt-PT")]
+		[Timeout(300000)]
+		public void Create_PreferredUiLanguageIsGenericVariant_CreatesLocalizationManagerForSpecificVariant(
+			string genericLocaleId, string countrySpecificLocalId)
 		{
+			LocalizationManager.ClearLoadedManagers();
 			var dir = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
-			var lm = LocalizationManager.Create(TranslationMemory.XLiff, "es", "Test", "Test", "1.0",
-				Path.Combine(dir, "../../../src/L10NSharpTests/TestXliff"), "", null, "");
-			Assert.IsFalse(lm.GetAvailableUILanguageTags().Contains("es"));
-			Assert.IsTrue(lm.GetAvailableUILanguageTags().Contains("es-ES"));
+			var lm = LocalizationManager.Create(TranslationMemory.XLiff, genericLocaleId, "Test", "Test", "1.0",
+				Path.Combine(dir, "../../../src/L10NSharpTests/TestXliff2"), "", null, "");
+			Assert.AreEqual($"Protección de configuraciones ({genericLocaleId})...",
+				lm.GetLocalizedString("SettingsProtection.LauncherButtonLabel", "don't use this"));
+			// The next two lines prove that the test data was not changed in a way that nullifies the expected pre-conditions
+			Assert.IsFalse(lm.GetAvailableUILanguageTags().Contains(genericLocaleId));
+			Assert.IsTrue(lm.GetAvailableUILanguageTags().Contains(countrySpecificLocalId));
 		}
 	}
 }

--- a/src/L10NSharpTests/LocalizationManagerXliffTests.cs
+++ b/src/L10NSharpTests/LocalizationManagerXliffTests.cs
@@ -13,12 +13,12 @@ namespace L10NSharp.Tests
 	public class LocalizationManagerXliffTests
 	{
 		/// <summary>
-		/// Indirectly, this is a test of LocalizationManagerInternal<XLiffDocument>.IsDesiredUiCultureAvailable,
+		/// Indirectly, this is a test of LocalizationManagerInternal&lt;XLiffDocument&gt;.IsDesiredUiCultureAvailable,
 		/// which is called by its Create method. This test was written to ensure that a dialog is not displayed
 		/// incorrectly telling the user that the requested UI language is unavailable and asking them which UI
 		/// Language to use instead. If the implementation is incorrect, we don't want the test to hang because
 		/// of the dialog box but rather to fail. And of course, if the test is being run in an interactive
-		/// environment, we also don't the developer to interact with the dialog, which could give a false
+		/// environment, we also don't want the developer to interact with the dialog, which could give a false
 		/// success. So we set the timeout to 3 seconds, which seems to be long enough to let the test run
 		/// successfully but short enough to prevent a developer from interacting with it.
 		/// </summary>

--- a/src/L10NSharpTests/LocalizationManagerXliffTests.cs
+++ b/src/L10NSharpTests/LocalizationManagerXliffTests.cs
@@ -1,0 +1,23 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace L10NSharp.Tests
+{
+	[TestFixture]
+	public class LocalizationManagerXliffTests
+	{
+		[Test]
+		[Timeout(3000)] // This ensures that if the UI pops up, a developer will not have time to respond and the test won't hang.
+		public void Create_PreferredUiLanguageIsGenericVariant_CreatesLocalizationManagerForSpecificVariant()
+		{
+			var dir = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
+			var lm = LocalizationManager.Create(TranslationMemory.XLiff, "es", "Test", "Test", "1.0",
+				Path.Combine(dir, "../../../src/L10NSharpTests/TestXliff"), "", null, "");
+			Assert.IsFalse(lm.GetAvailableUILanguageTags().Contains("es"));
+			Assert.IsTrue(lm.GetAvailableUILanguageTags().Contains("es-ES"));
+		}
+	}
+}

--- a/src/L10NSharpTests/TestXliff2/Test.en.xlf
+++ b/src/L10NSharpTests/TestXliff2/Test.en.xlf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff">
+<file source-language="en" product-version="1.0.0.0"  original="Nothing.dll" datatype="csharp">
+	<body>
+        <trans-unit id="SettingsProtection.CtrlShiftHint" approved="yes">
+            <source xml:lang="en">The button will show up when you hold down the Ctrl and Shift keys together.</source>
+            <note>ID: SettingsProtection.CtrlShiftHint</note>
+        </trans-unit>
+        <trans-unit id="SettingsProtection.LauncherButtonLabel">
+            <source xml:lang="en">Settings Protection...</source>
+            <note>ID: SettingsProtection.LauncherButtonLabel</note>
+        </trans-unit>
+	</body>
+</file>
+</xliff>

--- a/src/L10NSharpTests/TestXliff2/Test.es.xlf
+++ b/src/L10NSharpTests/TestXliff2/Test.es.xlf
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff">
+  <file source-language="en" target-language="es-ES" product-version="1.0.0.0"  original="Nothing.dll" datatype="csharp">
+    <body>
+      <trans-unit id="SettingsProtection.CtrlShiftHint" approved="yes">
+        <source xml:lang="en">The button will show up when you hold down the Ctrl and Shift keys together.</source>
+        <target xml:lang="es-ES">El botón se mostrará cuando se mantengan presionadas juntas las teclas Ctrl y Mayús.</target>
+        <alt-trans>
+          <target xml:lang="es-ES">El botón se mostrará cuando juntamente se presiona las teclas Ctrl y Mayús.</target>
+        </alt-trans>
+        <note>ID: SettingsProtection.CtrlShiftHint</note>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.LauncherButtonLabel">
+        <source xml:lang="en">Settings Protection...</source>
+        <target xml:lang="es-ES" state="translated">Protección de configuraciones (es)...</target>
+        <note>ID: SettingsProtection.LauncherButtonLabel</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/L10NSharpTests/TestXliff2/Test.pt.xlf
+++ b/src/L10NSharpTests/TestXliff2/Test.pt.xlf
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff">
+  <file source-language="en" target-language="pt-PT" product-version="1.0.0.0"  original="Nothing.dll" datatype="csharp">
+    <body>
+      <trans-unit id="SettingsProtection.LauncherButtonLabel">
+        <source xml:lang="en">Settings Protection...</source>
+        <target xml:lang="pt-PT" state="translated">Protección de configuraciones (pt)...</target>
+        <note>ID: SettingsProtection.LauncherButtonLabel</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
For programs that are switching from TMX-based localization to XLIFF-based, languages like Spanish (es) and Portuguese (pt) will typically use a langiage code that includes a country specifier (es-ES, pt-PT). The LocalizationManager already knows about these mappings and handles them ocrrectly when getting strings, but not when checking to see if the requested UI language is available.
If the caller requests a desired UI based on a two-letter language code that is not available, but there is a mapping to the corresponding (country-)specifiic locale, use that without displaying the "UI not available" dialog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/78)
<!-- Reviewable:end -->
