### PR TITLE
Fix a crashing bug inside L10NSharp scanning

### DIFF
--- a/src/L10NSharp/CodeReader/StringExtractor.cs
+++ b/src/L10NSharp/CodeReader/StringExtractor.cs
@@ -263,8 +263,16 @@ namespace L10NSharp.CodeReader
 
 			var methodsInType = new List<MethodBase>();
 
-			methodsInType.AddRange(type.GetConstructors(BindingFlags.Static |
-				BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
+			try
+			{
+				methodsInType.AddRange(type.GetConstructors(BindingFlags.Static |
+					BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
+			}
+			catch (TypeLoadException)
+			{
+				// Caused by assemblies that have odd runtime loading problems (e.g. SIL.Windows.Forms.Keyboarding). Ignore.
+				return;
+			}
 
 			try
 			{


### PR DESCRIPTION
This is currently killing Bloom on the master branch on Linux.  And
Bloom doesn't even care that much about the automatic scanning!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/80)
<!-- Reviewable:end -->
