### PR TITLE
Improve error handling

### DIFF
--- a/L10NSharp.sln.DotSettings
+++ b/L10NSharp.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Xliff/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/L10NSharp/CodeReader/StringExtractor.cs
+++ b/src/L10NSharp/CodeReader/StringExtractor.cs
@@ -320,6 +320,11 @@ namespace L10NSharp.CodeReader
 					// this can happen if we have a generic type (e.g. L10NSharp.dll). Ignore.
 					Console.WriteLine(e3.Message);
 				}
+				catch (Exception e4)
+				{
+					Console.WriteLine(e4.Message);
+					throw;
+				}
 			}
 		}
 

--- a/src/L10NSharp/UI/InitializationProgressDlg.cs
+++ b/src/L10NSharp/UI/InitializationProgressDlg.cs
@@ -34,16 +34,38 @@ namespace L10NSharp.UI
 
 		protected override void backgroundWorker_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
 		{
-			try
+			if (e.Error != null)
 			{
-				ExtractedInfo = (IEnumerable<LocalizingInfo>) e.Result;
+				var message = $"Error in extracting localizable strings: {e.Error.Message} ({e.Error})";
+				Console.WriteLine(message);
+
+				// Adding the error to the ExtractedInfo here serves two purposes.
+				// 1. It makes sure we get a valid file. Otherwise we get failures later.
+				// 2. It provides a way for the developer to see the actual error which caused extraction to fail.
+				ExtractedInfo = new[]
+				{
+					new LocalizingInfo("StringExtractor_Error")
+					{
+						LangId = "en",
+						Text = "An error occurred while collecting strings or there were no strings to collect. " +
+						       "Check comment for exception. Note, the exception may not occur again until you delete this file.",
+						Comment = message
+					}
+				};
 			}
-			catch (Exception ex)
+			else
 			{
-				Debug.WriteLine("Error in extracting localizable strings: {0} ({1})", ex.Message, e.Error);
+				try
+				{
+					ExtractedInfo = (IEnumerable<LocalizingInfo>)e.Result;
+				}
+				catch (Exception ex)
+				{
+					Debug.WriteLine($"Error in extracting localizable strings: {ex.Message} ({e.Error})");
+				}
 			}
+
 			Close();
 		}
-
 	}
 }

--- a/src/L10NSharp/XLiffUtils/XLiffLocalizationManager.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffLocalizationManager.cs
@@ -212,8 +212,20 @@ namespace L10NSharp.XLiffUtils
 				dlg.ShowDialog();
 				if (dlg.ExtractedInfo != null)
 				{
-					foreach (var locInfo in dlg.ExtractedInfo)
-						stringCache.UpdateLocalizedInfo(locInfo);
+					if (dlg.ExtractedInfo.Any())
+					{
+						foreach (var locInfo in dlg.ExtractedInfo)
+							stringCache.UpdateLocalizedInfo(locInfo);
+					}
+					else
+					{
+						stringCache.UpdateLocalizedInfo(new LocalizingInfo("_dummyEntryToGetValidFile")
+							{
+								LangId = "en",
+								Text =  "No strings were collected. This entry prevents an invalid, zero-length file. Delete this file to try regenerating it."
+							}
+						);
+					}
 				}
 			}
 


### PR DESCRIPTION
Don't cause a crash by generating a zero-length file.
Provide a mechanism by which the developer can get the root cause of extraction errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/85)
<!-- Reviewable:end -->
