### PR TITLE
Generate messages for all extraction errors

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,6 @@
+<Project>
+  <Target Name="CopyPackage" AfterTargets="Pack" Condition="'$(LOCAL_NUGET_REPO)'!='' AND '$(IsPackable)'=='true'">
+    <Copy SourceFiles="$(PackageOutputPath)/$(PackageId).$(PackageVersion).nupkg"
+      DestinationFolder="$(LOCAL_NUGET_REPO)"/>
+  </Target>
+</Project>

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ The tests can be run from the command line like this:
 It is also possible to run the tests from inside Visual Studio, Rider or MonoDevelop (if `mono5-sil`
 is installed and made the default Mono runtime).
 
+## Testing in client projects (as applicable):
+
+  * Set an enviroment variable `LOCAL_NUGET_REPO` with the path to a folder on your computer (or local network) to publish locally-built packages
+  * See [these instructions](https://docs.microsoft.com/en-us/nuget/hosting-packages/local-feeds) to enable local package sources
+  * `build /t:pack` will pack nuget packages and publish them to `LOCAL_NUGET_REPO`
+
+Further instructions at https://github.com/sillsdev/libpalaso/wiki/Developing-with-locally-modified-nuget-packages
+
 ## Working on UI related files
 
 The L10NSharp project uses SDK style .csproj files which don't allow the Designer to be used in

--- a/src/L10NSharp/UI/InitializationProgressDlg.cs
+++ b/src/L10NSharp/UI/InitializationProgressDlg.cs
@@ -39,33 +39,48 @@ namespace L10NSharp.UI
 				var message = $"Error in extracting localizable strings: {e.Error.Message} ({e.Error})";
 				Console.WriteLine(message);
 
-				// Adding the error to the ExtractedInfo here serves two purposes.
-				// 1. It makes sure we get a valid file. Otherwise we get failures later.
-				// 2. It provides a way for the developer to see the actual error which caused extraction to fail.
-				ExtractedInfo = new[]
-				{
-					new LocalizingInfo("StringExtractor_Error")
-					{
-						LangId = "en",
-						Text = "An error occurred while collecting strings or there were no strings to collect. " +
-						       "Check comment for exception. Note, the exception may not occur again until you delete this file.",
-						Comment = message
-					}
-				};
+				ReportError(message);
 			}
 			else
 			{
 				try
 				{
-					ExtractedInfo = (IEnumerable<LocalizingInfo>)e.Result;
+					if (e.Result is IEnumerable<LocalizingInfo> info)
+					{
+						ExtractedInfo = info;
+					}
+					else
+					{
+						var got = e.Result == null ? "null" : $"{e.Result.GetType()}: {e.Result}";
+						ReportError($"Expected IEnumerable<LocalizingInfo> but got {got}");
+					}
 				}
 				catch (Exception ex)
 				{
-					Debug.WriteLine($"Error in extracting localizable strings: {ex.Message} ({e.Error})");
+					var message = $"Error in extracting localizable strings: {ex.Message}";
+					Debug.WriteLine(message);
+					ReportError(message);
 				}
 			}
 
 			Close();
+		}
+
+		private void ReportError(string message)
+		{
+			// Adding the error to the ExtractedInfo here serves two purposes.
+			// 1. It makes sure we get a valid file. Otherwise we get failures later.
+			// 2. It provides a way for the developer to see the actual error which caused extraction to fail.
+			ExtractedInfo = new[]
+			{
+				new LocalizingInfo("StringExtractor_Error")
+				{
+					LangId = "en",
+					Text = "An error occurred while collecting strings or there were no strings to collect. " +
+					       "Check comment for exception. Note, the exception may not occur again until you delete this file.",
+					Comment = message
+				}
+			};
 		}
 	}
 }


### PR DESCRIPTION
If the result of extracting strings is null or the wrong type,
or if some other exception occurs, report it in the localizations
file. This gives developers information and prevents crashes later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/87)
<!-- Reviewable:end -->
