### PR TITLE
+semver:major Added ILocalizationManager parameter to StringsLocalizedHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - option `LocalizationManager.ThrowIfManagerDisposed` to not throw if LM disposed (BL-9904)
 
+### Changed
+
+- Added ILocalizationManager parameter to StringsLocalizedHandler
+
 ## [4.1.0] - 2021-03-04
 
 ### Changed

--- a/src/L10NSharp/TMXUtils/TMXLocalizationManager.cs
+++ b/src/L10NSharp/TMXUtils/TMXLocalizationManager.cs
@@ -674,7 +674,7 @@ namespace L10NSharp.TMXUtils
 			foreach (var component in ComponentCache.Keys)
 				ApplyLocalization(component);
 
-			LocalizeItemDlg<TMXDocument>.FireStringsLocalizedEvent();
+			LocalizeItemDlg<TMXDocument>.FireStringsLocalizedEvent(this);
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/src/L10NSharp/UI/LocalizeItemDlg.cs
+++ b/src/L10NSharp/UI/LocalizeItemDlg.cs
@@ -16,7 +16,7 @@ namespace L10NSharp.UI
 		public static Font DefaultDisplayFont { get; set; }
 
 		/// ------------------------------------------------------------------------------------
-		public delegate void StringsLocalizedHandler();
+		public delegate void StringsLocalizedHandler(ILocalizationManager localizationManager);
 		/// ------------------------------------------------------------------------------------
 		public delegate string SetDialogSettingsHandler(LocalizeItemDlg<T> dlg);
 		/// ------------------------------------------------------------------------------------
@@ -382,14 +382,13 @@ namespace L10NSharp.UI
 				_grid.EndEdit(DataGridViewDataErrorContexts.Commit);
 
 			if (_viewModel.Save())
-				FireStringsLocalizedEvent();
+				FireStringsLocalizedEvent(_callingManager);
 		}
 
 		/// ------------------------------------------------------------------------------------
-		internal static void FireStringsLocalizedEvent()
+		internal static void FireStringsLocalizedEvent(ILocalizationManager lm)
 		{
-			if (StringsLocalized != null)
-				StringsLocalized();
+			StringsLocalized?.Invoke(lm);
 		}
 
 		#endregion

--- a/src/L10NSharp/XLiffUtils/XLiffLocalizationManager.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffLocalizationManager.cs
@@ -727,7 +727,7 @@ namespace L10NSharp.XLiffUtils
 			foreach (var component in ComponentCache.Keys)
 				ApplyLocalization(component);
 
-			LocalizeItemDlg<XLiffDocument>.FireStringsLocalizedEvent();
+			LocalizeItemDlg<XLiffDocument>.FireStringsLocalizedEvent(this);
 		}
 
 		/// ------------------------------------------------------------------------------------


### PR DESCRIPTION
This is to address HT-417. It allows the consumer of the StringsLocalized event to respond appropriately based on the LocalizationManager (and avoid responding more than once if the application creates more than one LM).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/89)
<!-- Reviewable:end -->
