### PR TITLE
Make lazy loading of xliffs thread-safe (BL-11086)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - option `LocalizationManager.ThrowIfManagerDisposed` to not throw if LM disposed (BL-9904)
+- XliffBody.TransUnitsUnordered for where you just need to enumerate all of them.
+- (Made public) XliffBody.AddTransUnit and .RemoveTransUnit for where you need to modify.
+- XliffBody.TransUnitsForXml. This is necessarily public to support (backwards-compatible)
+    serialization and deserialization in XML, but is not intended for any other purpose.
 
 ### Changed
 
+- Made string retrieval operations on Xliff-based LocalizationManagers thread-safe
 - Added ILocalizationManager parameter to StringsLocalizedHandler
 - It's long been a convention that xliff file names are module.lang.xlf (e.g., Bloom.fr.xlf)
 or else kept in language-code folders (.../en/Bloom.xlf) if UseLanguageCodeFolders is set.
@@ -29,6 +34,11 @@ With the latest changes, this is required: the language name indicated in these 
 name must match the language declared in the target-language attribute, or at least match the
 first element of the target-language (e.g., a file with target-languge es-ES may be stored in
 file like Bloom.es.xlf or .../es/Bloom.xlf).
+
+### Removed
+
+- XliffBody.TransUnits, as there is no good way to make this thread-safe for all the ways
+    it could be used, such as adding items to the list. (See Added for replacements.)
 
 ## [4.1.0] - 2021-03-04
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ the lang component in the file path may be either the full tag (Whatever.es-ES.x
 es-ES/Whatever.xlf) or its first component, the actual language tag (Whatever.es.xlf
 or es/Whatever.xlf).
 
+## Thread safety
+
+In general, L10NSharp is not written with thread safety in mind; callers should ensure
+that only one thread at a time enters L10NSharp methods. There is one exception: we have
+attempted to make the various varieties of GetString thread-safe, but currently only
+when the xliff translation memory file approach is used.
+
 ## L10NSharpExtender
 
 To localize a Windows Forms form or control, simply add the `L10NSharpExtender`. It will

--- a/src/CheckOrFixXliff/Program.cs
+++ b/src/CheckOrFixXliff/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -203,7 +203,7 @@ namespace CheckOrFixXliff
 			var doc = XLiffDocument.Read(filename);
 			var dictSourceMarkers = new Dictionary<string, int>();
 			var dictTargetMarkers = new Dictionary<string, int>();
-			foreach (var tu in doc.File.Body.TransUnits)
+			foreach (var tu in doc.File.Body.TransUnitsUnordered)
 			{
 				if (tu.Source == null || tu.Target == null)
 					continue;

--- a/src/L10NSharp/LocalizationManager.cs
+++ b/src/L10NSharp/LocalizationManager.cs
@@ -478,6 +478,8 @@ namespace L10NSharp
 		/// <summary>
 		/// Gets a string for the specified string id. The englishText is returned when
 		/// a string cannot be found for the specified id and the current UI language.
+		/// Currently this and other overloads are intended to be thread-safe when
+		/// the xliff backing store is used.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		public static string GetString(string stringId, string englishText)

--- a/src/L10NSharp/LocalizationManagerInternal.cs
+++ b/src/L10NSharp/LocalizationManagerInternal.cs
@@ -94,14 +94,9 @@ namespace L10NSharp
 			// We may know about a closely related language (e.g., we have es-ES but were asked for es-BR).
 			// If so we want to return true.
 			var fallbackLangId = MapToExistingLanguageIfPossible(desiredUiLangId);
-			// However, MapToExistingLanguageIfPossible often returns the code we started with.
-			// This can indicate that we don't need to map it since we have exactly that localization,
-			// but in such a case, IsLocalizationAvailable would have returned true above and we would
-			// not get here. However, it also returns an unchanged code for a locale about which we
-			// know nothing at all...there is no closely related language for which we have a
-			// localization. In such a case, if we don't detect it, we'd be making a recursive call
-			// with the same argument, which would produce stack overflow. So if we didn't find
-			// a different language to try, we must fail now.
+			// If the input and output of MapToExistingLanguageIfPossible are the same then there is no mapping
+			// known for the language and we should return false instead of infinitely recursing.
+			// (Storing such redundant mappings makes other code more performant.)
 			if (fallbackLangId == desiredUiLangId)
 				return false;
 
@@ -690,8 +685,6 @@ namespace L10NSharp
 				if (MapToExistingLanguage.TryGetValue(langId, out var realId2))
 					return realId2;
 
-
-				var pieces = langId.Split('-');
 				// The above will find the appropriate result
 				// if we are looking for, e.g., es-ES and have loaded a file in the es folder
 				// which actually contains es-ES data. But it's also just conceivable that we have such data
@@ -699,6 +692,7 @@ namespace L10NSharp
 				// if they weren't there already, for es->es-ES and es-ES->es-ES,
 				// whether we found that data in the es folder or the es-ES one,
 				// but now (since we didn't find separate data for es-BR) we'd like to map that to es-ES, too.
+				var pieces = langId.Split('-');
 				if (MapToExistingLanguage.ContainsKey(pieces[0]))
 				{
 					var realLangId2 = MapToExistingLanguage[pieces[0]];

--- a/src/L10NSharp/LocalizationManagerInternal.cs
+++ b/src/L10NSharp/LocalizationManagerInternal.cs
@@ -2,6 +2,7 @@
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
@@ -23,10 +24,21 @@ namespace L10NSharp
 
 		/// <summary>
 		/// Map from the given language code to a variant we actually have.  (It can map from a
-		/// language code onto itself.)
+		/// language code onto itself. It can also map a code we know we don't have any variant of
+		/// onto itself.)
+		/// Because this is a concurrent dictionary, and lazy loading only puts correct data into
+		/// it as a result of loading xliff files, it is safe (and desirable for performance) to
+		/// attempt a retrieval from it without locking. However, modifications and possible loading
+		/// of xliff files requires locking on LazyLoadLock. Also, since the data is incomplete
+		/// until all lazy loading has been done, if you don't get a hit you must take steps to
+		/// try to load any relevant missing data. This is currently handled in
+		/// MapToExistingLanguageIfPossible(), which should always be used for simple retrievals.
 		/// </summary>
-		internal static Dictionary<string, string> MapToExistingLanguage = new Dictionary<string, string>();
+		internal static ConcurrentDictionary<string, string> MapToExistingLanguage = new ConcurrentDictionary<string, string>();
 
+		// If documents are loaded lazily, this lock must be held while loading one, or while using MapToExistingLanguage
+		// in a way that might cause loading.
+		internal static object LazyLoadLock = new object();
 
 		private static readonly Dictionary<string, ILocalizationManagerInternal<T>> s_loadedManagers =
 			new Dictionary<string, ILocalizationManagerInternal<T>>();
@@ -79,9 +91,21 @@ namespace L10NSharp
 		{
 			if (IsLocalizationAvailable(desiredUiLangId))
 				return true;
-			return MapToExistingLanguage.TryGetValue(desiredUiLangId, out string fallbackLangId) &&
-			       fallbackLangId != desiredUiLangId && // just in case, prevent stack overflow
-			       IsDesiredUiCultureAvailable(fallbackLangId);
+			// We may know about a closely related language (e.g., we have es-ES but were asked for es-BR).
+			// If so we want to return true.
+			var fallbackLangId = MapToExistingLanguageIfPossible(desiredUiLangId);
+			// However, MapToExistingLanguageIfPossible often returns the code we started with.
+			// This can indicate that we don't need to map it since we have exactly that localization,
+			// but in such a case, IsLocalizationAvailable would have returned true above and we would
+			// not get here. However, it also returns an unchanged code for a locale about which we
+			// know nothing at all...there is no closely related language for which we have a
+			// localization. In such a case, if we don't detect it, we'd be making a recursive call
+			// with the same argument, which would produce stack overflow. So if we didn't find
+			// a different language to try, we must fail now.
+			if (fallbackLangId == desiredUiLangId)
+				return false;
+
+			return IsDesiredUiCultureAvailable(fallbackLangId);
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -646,12 +670,48 @@ namespace L10NSharp
 		/// Get the best possible language id to use for retrieving a string.  In most cases,
 		/// we would expect an identity transformation.  But this allows "es-ES" to map to "es"
 		/// and vice versa depending on the actual data available.
+		/// With lazy loading of xliff documents, it's possible that MapToExistingLanguage does
+		/// not yet contain data about this language. In that case, get the lock for
+		/// loading xliff docs, load any relevant ones, and try again.
 		/// </summary>
 		internal static string MapToExistingLanguageIfPossible(string langId)
 		{
 			if (string.IsNullOrEmpty(langId))
 				return null;
-			return MapToExistingLanguage.TryGetValue(langId, out var realId) ? realId : langId;
+			// It's a concurrent dictionary, so we can (for performance) try this without a lock.
+			if (MapToExistingLanguage.TryGetValue(langId, out var realId))
+				return realId;
+			lock (LazyLoadLock)
+			{
+				// Load any available data in any LM related to this language code.
+				// If files are loaded, this will add appropriate entries to MapToExistingLanguage.
+				foreach (var lm in LoadedManagers.Values)
+					lm.StringCache.TryGetDocument(langId, out _);
+				if (MapToExistingLanguage.TryGetValue(langId, out var realId2))
+					return realId2;
+
+
+				var pieces = langId.Split('-');
+				// The above will find the appropriate result
+				// if we are looking for, e.g., es-ES and have loaded a file in the es folder
+				// which actually contains es-ES data. But it's also just conceivable that we have such data
+				// and are now looking for es-BR. The code above will put entries in MapToExistingLanguage,
+				// if they weren't there already, for es->es-ES and es-ES->es-ES,
+				// whether we found that data in the es folder or the es-ES one,
+				// but now (since we didn't find separate data for es-BR) we'd like to map that to es-ES, too.
+				if (MapToExistingLanguage.ContainsKey(pieces[0]))
+				{
+					var realLangId2 = MapToExistingLanguage[pieces[0]];
+					MapToExistingLanguage.TryAdd(langId, realLangId2);
+					return realLangId2;
+				}
+
+				// In case we haven't found ANY useful mapping for langId (we haven't localized into it or any
+				// variation of it), we don't need to do all the fallback logic again next time.
+				if (!MapToExistingLanguage.ContainsKey(langId))
+					MapToExistingLanguage[langId] = langId;
+				return langId;
+			}
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -707,32 +767,7 @@ namespace L10NSharp
 			var bestAnswer = LoadedManagers.Values.Select(lm =>
 					lm.StringCache.GetValueForExactLangAndId(realLangId, stringId, true))
 				.FirstOrDefault(text => !string.IsNullOrEmpty(text));
-			if (string.IsNullOrEmpty(bestAnswer) && langId.Contains('-') &&
-				!MapToExistingLanguage.ContainsKey(langId))
-			{
-				var pieces = langId.Split('-');
-				if (MapToExistingLanguage.ContainsKey(pieces[0]))
-				{
-					var realLangId2 = MapToExistingLanguage[pieces[0]];
-					MapToExistingLanguage.Add(langId, realLangId2);
-					if (realLangId != realLangId2)
-					{
-						bestAnswer = LoadedManagers.Values.Select(lm =>
-								lm.StringCache.GetValueForExactLangAndId(realLangId2, stringId, true))
-							.FirstOrDefault(text => !string.IsNullOrEmpty(text));
-						if (!string.IsNullOrEmpty(bestAnswer))
-						{
-							languageIdUsed = realLangId2;
-							return bestAnswer;
-						}
-					}
-				}
-
-				if (!MapToExistingLanguage.ContainsKey(langId))
-					MapToExistingLanguage[langId] = langId; // prevent trying this again and again.
-				languageIdUsed = null;
-				return null;
-			}
+			
 			languageIdUsed = realLangId;
 			return bestAnswer;
 		}

--- a/src/L10NSharp/TMXUtils/TMXLocalizedStringCache.cs
+++ b/src/L10NSharp/TMXUtils/TMXLocalizedStringCache.cs
@@ -132,8 +132,10 @@ namespace L10NSharp.TMXUtils
 					if (pieces.Length > 1)
 					{
 						if (!LocalizationManagerInternal<TMXDocument>.MapToExistingLanguage.ContainsKey
-						(pieces[0]))
-							LocalizationManagerInternal<TMXDocument>.MapToExistingLanguage.Add(pieces[0], langId);
+							    (pieces[0]))
+						{
+							LocalizationManagerInternal<TMXDocument>.MapToExistingLanguage.TryAdd(pieces[0], langId);
+						}
 					}
 					// Identity mapping always wins.  Storing it simplifies code elsewhere.
 					LocalizationManagerInternal<TMXDocument>.MapToExistingLanguage[langId] = langId;

--- a/src/L10NSharp/XLiffUtils/XLiffBody.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffBody.cs
@@ -68,42 +68,14 @@ namespace L10NSharp.XLiffUtils
 		}
 
 		#region Properties
-		/// ------------------------------------------------------------------------------------
-		/// <summary>
-		/// Gets the list of translation units in the file.
-		/// Note, a new list is generated each time, so this can be inefficient. Consider using
-		/// TransUnitsUnordered if you don't absolutely need a list. This method is retained
-		/// mainly for backwards compatibility.
-		/// Modifying the list returned (unlike in previous versions) will have no effect on
-		/// the XliffBody.
-		/// The list returned is not in any predictable order, specifically NOT the same order
-		/// as any list previously passed to the setter.
-		/// </summary>
-		/// ------------------------------------------------------------------------------------
-		[XmlIgnore]
-		public List<XLiffTransUnit> TransUnits
-		{
-			get
-			{
-				var result = TransUnitsUnordered.ToList();
-				return result;
-			}
-			set
-			{
-				_transUnitDict.Clear();
-				foreach (var tu in value)
-				{
-					AddTransUnit(tu);
-				}
-			}
-		}
 
 		/// <summary>
 		/// This property exists solely to support serializing and deserializing an XliffBody in a
-		/// backwards-compatible way. Previously, we simply put this annotation on TransUnits.
-		/// However, the serialization code assumes it can get the list and use Add to put things
-		/// into it, which does not work with the current version. The List wrapper implements just
-		/// the functions required of an IEnumerable property that can be serialized and deserialized.
+		/// backwards-compatible way. The serialization code assumes it can get the object and use
+		/// Add to put things into it when deserializing as well as running the enumeration to get
+		/// the things to serialize. The ListWrapper implements just those necessary functions.
+		/// This property must be public for the serializer to work, but is not intended for use
+		/// by other clients.
 		/// </summary>
 		[XmlElement("trans-unit")]
 		public ListWrapper TransUnitsForXml
@@ -115,7 +87,6 @@ namespace L10NSharp.XLiffUtils
 				return new ListWrapper(result, this);
 			}
 		}
-
 
 		[XmlIgnore] public IEnumerable<XLiffTransUnit> TransUnitsUnordered => _transUnitDict.Values;
 
@@ -203,7 +174,7 @@ namespace L10NSharp.XLiffUtils
 			_transUnitDict[key] = tu;
 			return true;
 		}
-		internal bool AddTransUnit(XLiffTransUnit tu)
+		public bool AddTransUnit(XLiffTransUnit tu)
 		{
 			if (!AddTransUnitRaw(tu))
 				return false;
@@ -245,7 +216,7 @@ namespace L10NSharp.XLiffUtils
 		/// Removes the specified translation unit.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		internal void RemoveTransUnit(XLiffTransUnit tu)
+		public void RemoveTransUnit(XLiffTransUnit tu)
 		{
 			// if the ID is null, it can't be in our dictionary, unless someone
 			// cheated and changed the ID by putting it there after inserting it.

--- a/src/L10NSharp/XLiffUtils/XLiffBody.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffBody.cs
@@ -14,8 +14,11 @@
 // </remarks>
 // ---------------------------------------------------------------------------------------------
 using System;
+using System.Collections;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Collections.Generic;
+using System.Threading;
 using System.Xml.Serialization;
 using L10NSharp.XLiffUtils;
 
@@ -29,34 +32,92 @@ namespace L10NSharp.XLiffUtils
 		// This is used when translation unit IDs are not found in the file (which seems to be
 		// the case with Lingobit XLiff files).
 		private int _transUnitId;
-		private bool _idsVerified;
-		private List<XLiffTransUnit> _transUnits = new List<XLiffTransUnit>();
+		static SpinLock _transUnitIdLock;
+
+		private ConcurrentDictionary<string, XLiffTransUnit> _transUnitDict =
+			new ConcurrentDictionary<string, XLiffTransUnit>();
+
+		private object mutex = new object(); // lock for accessing non-concurrent variables.
 		private int _translatedCount = -1;
 		private int _approvedCount = -1;
+
+		public class ListWrapper : IEnumerable<XLiffTransUnit>
+		{
+			private IEnumerable<XLiffTransUnit> _list;
+			private XLiffBody _body;
+
+			public ListWrapper(IEnumerable<XLiffTransUnit> startWith, XLiffBody body)
+			{
+				_list = startWith;
+				_body = body;
+			}
+			public IEnumerator<XLiffTransUnit> GetEnumerator()
+			{
+				return _list.GetEnumerator();
+			}
+
+			IEnumerator IEnumerable.GetEnumerator()
+			{
+				return GetEnumerator();
+			}
+
+			public void Add(XLiffTransUnit item)
+			{
+				_body.AddTransUnitRaw(item);
+			}
+		}
 
 		#region Properties
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// Gets the list of translation units in the file.
+		/// Note, a new list is generated each time, so this can be inefficient. Consider using
+		/// TransUnitsUnordered if you don't absolutely need a list. This method is retained
+		/// mainly for backwards compatibility.
+		/// Modifying the list returned (unlike in previous versions) will have no effect on
+		/// the XliffBody.
+		/// The list returned is not in any predictable order, specifically NOT the same order
+		/// as any list previously passed to the setter.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		[XmlElement("trans-unit")]
+		[XmlIgnore]
 		public List<XLiffTransUnit> TransUnits
 		{
 			get
 			{
-				if (!_idsVerified && _transUnits != null && _transUnits.Count > 0)
-				{
-					foreach (var tu in _transUnits.Where(tu => string.IsNullOrEmpty(tu.Id)))
-						tu.Id = (++_transUnitId).ToString();
-
-					_idsVerified = true;
-				}
-
-				return _transUnits;
+				var result = TransUnitsUnordered.ToList();
+				return result;
 			}
-			set { _transUnits = value; }
+			set
+			{
+				_transUnitDict.Clear();
+				foreach (var tu in value)
+				{
+					AddTransUnit(tu);
+				}
+			}
 		}
+
+		/// <summary>
+		/// This property exists solely to support serializing and deserializing an XliffBody in a
+		/// backwards-compatible way. Previously, we simply put this annotation on TransUnits.
+		/// However, the serialization code assumes it can get the list and use Add to put things
+		/// into it, which does not work with the current version. The List wrapper implements just
+		/// the functions required of an IEnumerable property that can be serialized and deserialized.
+		/// </summary>
+		[XmlElement("trans-unit")]
+		public ListWrapper TransUnitsForXml
+		{
+			get
+			{
+				var result = TransUnitsUnordered.ToList();
+				result.Sort(XLiffLocalizedStringCache.TuComparer);
+				return new ListWrapper(result, this);
+			}
+		}
+
+
+		[XmlIgnore] public IEnumerable<XLiffTransUnit> TransUnitsUnordered => _transUnitDict.Values;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -66,7 +127,7 @@ namespace L10NSharp.XLiffUtils
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[XmlIgnore]
-		public readonly Dictionary<string, string> TranslationsById = new Dictionary<string, string>();
+		public readonly ConcurrentDictionary<string, string> TranslationsById = new ConcurrentDictionary<string, string>();
 		#endregion
 
 
@@ -78,17 +139,22 @@ namespace L10NSharp.XLiffUtils
 		/// ------------------------------------------------------------------------------------
 		internal XLiffTransUnit GetTransUnitForId(string id)
 		{
-			return _transUnits.FirstOrDefault(tu => tu.Id == id);
+			_transUnitDict.TryGetValue(id, out XLiffTransUnit result);
+			return result;
 		}
 
 		/// <summary>
 		/// When all but the last part of the id changed, this can help reunite things
 		/// </summary>
-		internal XLiffTransUnit GetTransUnitForOrphan(XLiffTransUnit orphan)
+		internal XLiffTransUnit GetTransUnitForOrphan(XLiffTransUnit orphan, XLiffBody source)
 		{
 			var terminalIdToMatch = XLiffLocalizedStringCache.GetTerminalIdPart(orphan.Id);
 			var defaultTextToMatch = GetDefaultVariantValue(orphan);
-			return _transUnits.FirstOrDefault(tu => XLiffLocalizedStringCache.GetTerminalIdPart(tu.Id) == terminalIdToMatch && GetDefaultVariantValue(tu) == defaultTextToMatch);
+			return TransUnitsUnordered.FirstOrDefault(tu =>
+				XLiffLocalizedStringCache.GetTerminalIdPart(tu.Id) ==
+				terminalIdToMatch // require last part of ID to match
+				&& GetDefaultVariantValue(tu) == defaultTextToMatch // require text to match
+				&& source?.GetTransUnitForId(tu.Id) == null); // and translation does not already have an element for this
 		}
 
 		string GetDefaultVariantValue(XLiffTransUnit tu)
@@ -104,19 +170,44 @@ namespace L10NSharp.XLiffUtils
 		/// <param name="tu">The translation unit.</param>
 		/// <returns>true if the translation unit was successfully added. Otherwise, false.</returns>
 		/// ------------------------------------------------------------------------------------
-		internal bool AddTransUnit(XLiffTransUnit tu)
+		internal bool AddTransUnitRaw(XLiffTransUnit tu)
 		{
 			if (tu == null || tu.IsEmpty)
 				return false;
 
-			if (tu.Id == null)
-				tu.Id = (++_transUnitId).ToString();
+			bool lockTaken = false;
+			string key;
+			try
+			{
+				_transUnitIdLock.Enter(ref lockTaken);
+				// Efficiently lock this very small task so that if we need to modify
+				// the TU, the key that it gets is guaranteed to be the one used to insert
+				// it into the dictionary. This assumes nothing else modifies IDs once they
+				// are in this system: once our locked code has given the TU an ID, any other
+				// thread will see that it is non-empty.
+				key = tu.Id;
+				if (string.IsNullOrEmpty(key))
+				{
+					tu.Id = (System.Threading.Interlocked.Increment(ref _transUnitId)).ToString();
+					key = tu.Id;
+				}
+			}
+			finally
+			{
+				if (lockTaken) _transUnitIdLock.Exit(false);
+			}
 
 			// If a translation unit with the specified id already exists, then quit here.
 			if (GetTransUnitForId(tu.Id) != null)
 				return false;
-
-			_transUnits.Add(tu);
+			_transUnitDict[key] = tu;
+			return true;
+		}
+		internal bool AddTransUnit(XLiffTransUnit tu)
+		{
+			if (!AddTransUnitRaw(tu))
+				return false;
+		
 			// If the target exists, store its value in the dictionary lookup.  Otherwise, store
 			// the source value there.
 			if (tu.Target != null && tu.Target.Value != null)
@@ -156,23 +247,13 @@ namespace L10NSharp.XLiffUtils
 		/// ------------------------------------------------------------------------------------
 		internal void RemoveTransUnit(XLiffTransUnit tu)
 		{
-			if (tu == null)
+			// if the ID is null, it can't be in our dictionary, unless someone
+			// cheated and changed the ID by putting it there after inserting it.
+			if (tu == null || tu.Id == null)
 				return;
 
-			if (_transUnits.Contains(tu))
-			{
-				_transUnits.Remove(tu);
-			}
-			else if (tu.Id != null)
-			{
-				var tmptu = GetTransUnitForId(tu.Id);
-				if (tmptu != null)
-				{
-					_transUnits.Remove(tmptu);
-				}
-			}
-			if (tu.Id != null)
-				TranslationsById.Remove(tu.Id);
+			_transUnitDict.TryRemove(tu.Id, out _);
+			TranslationsById.TryRemove(tu.Id, out _);
 		}
 
 		#endregion
@@ -187,26 +268,30 @@ namespace L10NSharp.XLiffUtils
 		{
 			get
 			{
-				if (_translatedCount < 0)
+				lock (mutex)
 				{
-					_translatedCount = 0;
-					foreach (var tu in TransUnits)
+					if (_translatedCount < 0)
 					{
-						if (tu.Target == null || string.IsNullOrWhiteSpace(tu.Target.Value))
-							continue;
-						if (tu.TranslationStatus == TranslationStatus.Approved ||
-							tu.Target.TargetState == XLiffTransUnitVariant.TranslationState.Translated)
+						_translatedCount = 0;
+						foreach (var tu in TransUnitsUnordered)
 						{
-							++_translatedCount;
-						}
-						else if (tu.Target.Value != tu.Source.Value &&
-							tu.Target.TargetState == XLiffTransUnitVariant.TranslationState.Undefined)
-						{
-							++_translatedCount;
+							if (tu.Target == null || string.IsNullOrWhiteSpace(tu.Target.Value))
+								continue;
+							if (tu.TranslationStatus == TranslationStatus.Approved ||
+							    tu.Target.TargetState == XLiffTransUnitVariant.TranslationState.Translated)
+							{
+								++_translatedCount;
+							}
+							else if (tu.Target.Value != tu.Source.Value &&
+							         tu.Target.TargetState == XLiffTransUnitVariant.TranslationState.Undefined)
+							{
+								++_translatedCount;
+							}
 						}
 					}
+
+					return _translatedCount;
 				}
-				return _translatedCount;
 			}
 		}
 
@@ -220,25 +305,29 @@ namespace L10NSharp.XLiffUtils
 		{
 			get
 			{
-				if (_approvedCount < 0)
+				lock (mutex)
 				{
-					_approvedCount = 0;
-					foreach (var tu in TransUnits)
+					if (_approvedCount < 0)
 					{
-						if (tu.Target == null || string.IsNullOrWhiteSpace(tu.Target.Value))
-							continue;
-						if (tu.TranslationStatus == TranslationStatus.Approved)
-							++_approvedCount;
+						_approvedCount = 0;
+						foreach (var tu in TransUnitsUnordered)
+						{
+							if (tu.Target == null || string.IsNullOrWhiteSpace(tu.Target.Value))
+								continue;
+							if (tu.TranslationStatus == TranslationStatus.Approved)
+								++_approvedCount;
+						}
 					}
+
+					return _approvedCount;
 				}
-				return _approvedCount;
 			}
 		}
 
 		/// <summary>
 		/// Return the total number of strings.
 		/// </summary>
-		internal int StringCount => TransUnits.Count;
+		internal int StringCount => _transUnitDict.Count;
 	}
 
 	#endregion

--- a/src/L10NSharp/XLiffUtils/XLiffDocument.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffDocument.cs
@@ -82,8 +82,8 @@ namespace L10NSharp.XLiffUtils
 		/// ------------------------------------------------------------------------------------
 		public IEnumerable<XLiffTransUnit> GetTransUnitsForTextInLang(string langId, string text)
 		{
-			return from tu in File.Body.TransUnits
-				let variant = tu.GetVariantForLang(langId)
+			return from tu in File.Body.TransUnitsUnordered
+				   let variant = tu.GetVariantForLang(langId)
 				where variant != null && variant.Value == text
 				select tu;
 		}
@@ -162,7 +162,7 @@ namespace L10NSharp.XLiffUtils
 			var langId = xLiffDoc.File.TargetLang;
 			if (string.IsNullOrEmpty(langId))
 				langId = xLiffDoc.File.SourceLang;
-			foreach (var tu in xLiffDoc.File.Body.TransUnits)
+			foreach (var tu in xLiffDoc.File.Body.TransUnitsUnordered)
 			{
 				if (xLiffDoc.File.Body.TranslationsById.ContainsKey(tu.Id))
 				{
@@ -176,7 +176,7 @@ namespace L10NSharp.XLiffUtils
 				{
 					var target = tu.GetVariantForLang(langId);
 					if (target != null && !string.IsNullOrEmpty(target.Value))
-						xLiffDoc.File.Body.TranslationsById.Add(tu.Id, target.Value);
+						xLiffDoc.File.Body.TranslationsById[tu.Id] = target.Value;
 				}
 			}
 
@@ -189,10 +189,13 @@ namespace L10NSharp.XLiffUtils
 		/// When we change ids after people have already been localizing, we have a BIG PROBLEM.
 		/// This helps with the common case were we just changed the hierarchical organization of the id,
 		/// that is, the parts of the id before th final '.'.
+		/// If provided with the source document of the possible orphan, will not answer one that
+		/// has an ID matching something in that. (This argument should always be supplied, but
+		/// for backwards compatibility we allow it to be omitted.)
 		/// </summary>
-		public XLiffTransUnit GetTransUnitForOrphan(XLiffTransUnit orphan)
+		public XLiffTransUnit GetTransUnitForOrphan(XLiffTransUnit orphan, XLiffBody source = null)
 		{
-			return File.Body.GetTransUnitForOrphan(orphan);
+			return File.Body.GetTransUnitForOrphan(orphan, source);
 		}
 
 		/// <summary>

--- a/src/L10NSharp/XLiffUtils/XLiffLocalizationManager.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffLocalizationManager.cs
@@ -1217,9 +1217,9 @@ namespace L10NSharp.XLiffUtils
 
 			// write out the newly-found units, comparing against units with the same ids
 			// found in the old XLIFF file.
-			foreach (var tu in xliffNew.File.Body.TransUnits)
+			foreach (var tu in xliffNew.File.Body.TransUnitsUnordered)
 			{
-				xliffOutput.File.Body.TransUnits.Add(tu);
+				xliffOutput.File.Body.AddTransUnit(tu);
 				if (tu.Dynamic)
 					++newDynamicCount;
 				if (xliffOld != null)
@@ -1271,12 +1271,12 @@ namespace L10NSharp.XLiffUtils
 			// in the new scan.
 			if (xliffOld != null)
 			{
-				foreach (var tu in xliffOld.File.Body.TransUnits)
+				foreach (var tu in xliffOld.File.Body.TransUnitsUnordered)
 				{
 					var tuNew = xliffNew.File.Body.GetTransUnitForId(tu.Id);
 					if (tuNew == null)
 					{
-						xliffOutput.File.Body.TransUnits.Add(tu);
+						xliffOutput.File.Body.AddTransUnit(tu);
 						if (tu.Dynamic)
 						{
 							++missingDynamicStringCount;
@@ -1345,7 +1345,6 @@ namespace L10NSharp.XLiffUtils
 						Console.WriteLine("    {0}", id);
 				}
 			}
-			xliffOutput.File.Body.TransUnits.Sort(XLiffLocalizedStringCache.TuComparer);
 			return xliffOutput;
 		}
 

--- a/src/L10NSharp/XLiffUtils/XLiffLocalizedStringCache.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffLocalizedStringCache.cs
@@ -93,7 +93,7 @@ namespace L10NSharp.XLiffUtils
 				return true;
 			lock (LocalizationManagerInternal<XLiffDocument>.LazyLoadLock)
 			{
-				LoadXliff(langId);
+				LoadXliffAndUpdateExistingLanguageMap(langId);
 			}
 
 			return XliffDocuments.TryGetValue(langId, out doc);
@@ -163,7 +163,7 @@ namespace L10NSharp.XLiffUtils
 		/// to what we find. 
 		/// Use only from TryGetDocument. Should hold LazyLoadLock.
 		/// </summary>
-		private void LoadXliff(string langId)
+		private void LoadXliffAndUpdateExistingLanguageMap(string langId)
 		{
 			if (!_unloadedXliffDocuments.TryRemove(langId, out string file))
 			{
@@ -210,7 +210,7 @@ namespace L10NSharp.XLiffUtils
 
 			XliffDocuments.TryAdd(targetLang, xliffDoc);
 			var defunctUnits = new List<XLiffTransUnit>();
-			foreach (var tu in xliffDoc.File.Body.TransUnits) // need a list here because we may modify it while enumerating
+			foreach (var tu in xliffDoc.File.Body.TransUnitsUnordered.ToList()) // need a list here because we may modify it while enumerating
 			{
 				// This block attempts to find 'orphans', that is, localizations that have been done using an obsolete ID.
 				// We assume the default language Xliff has only current IDs, and therefore don't look for orphans in that case.

--- a/src/L10NSharp/XLiffUtils/XLiffTransUnitUpdater.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffTransUnitUpdater.cs
@@ -203,7 +203,7 @@ namespace L10NSharp.XLiffUtils
 			// If we're removing an existing translation, we can quit now.
 			if (string.IsNullOrEmpty(newValue))
 			{
-				xliffTarget.File.Body.TranslationsById.Remove(tuId);
+				xliffTarget.File.Body.TranslationsById.TryRemove(tuId, out _);
 				return tuTarget;
 			}
 

--- a/src/L10NSharpTests/XLiffLocalizationManagerTests.cs
+++ b/src/L10NSharpTests/XLiffLocalizationManagerTests.cs
@@ -2,6 +2,7 @@
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Xml.Linq;
 using L10NSharp.XLiffUtils;
@@ -185,9 +186,9 @@ namespace L10NSharp.Tests
 
 			var mergedDoc = XLiffLocalizationManager.MergeXliffDocuments(newDoc, oldDoc, true);
 			Assert.IsNotNull(mergedDoc);
-			Assert.That(5, Is.EqualTo(oldDoc.File.Body.TransUnits.Count));
-			Assert.That(6, Is.EqualTo(newDoc.File.Body.TransUnits.Count));
-			Assert.That(8, Is.EqualTo(mergedDoc.File.Body.TransUnits.Count));
+			Assert.That(5, Is.EqualTo(oldDoc.File.Body.TransUnitsUnordered.Count()));
+			Assert.That(6, Is.EqualTo(newDoc.File.Body.TransUnitsUnordered.Count()));
+			Assert.That(8, Is.EqualTo(mergedDoc.File.Body.TransUnitsUnordered.Count()));
 
 			var tu = mergedDoc.GetTransUnitForId("This.test");
 			CheckMergedTransUnit(tu, "This is a test.",


### PR DESCRIPTION
Also makes all methods consistently handle fall-back from e.g. es-BR to es-ES.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/93)
<!-- Reviewable:end -->
