### PR TITLE
Remove progress dialogs for xliff initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- remove progress dialog when initializating Xliff localization managers (BL-11157)
 - Made string retrieval operations on Xliff-based LocalizationManagers thread-safe
 - Added ILocalizationManager parameter to StringsLocalizedHandler
 - It's long been a convention that xliff file names are module.lang.xlf (e.g., Bloom.fr.xlf)


### PR DESCRIPTION
This was discussed at the conference.  I think this is the minimal
change to the code that allows current behavior for programs that may
still benefit from it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/95)
<!-- Reviewable:end -->
