### PR TITLE
SP-2269: Made StringsLocalized fire for each modified LocalizatinoManager

### DIFF
--- a/src/L10NSharp/TMXUtils/TMXXmlSerializationHelper.cs
+++ b/src/L10NSharp/TMXUtils/TMXXmlSerializationHelper.cs
@@ -2,7 +2,6 @@ using System;
 using System.Text;
 using System.IO;
 using System.Xml.Serialization;
-using System.Diagnostics;
 using System.Xml;
 using System.Reflection;
 

--- a/src/L10NSharp/UI/LocalizeItemDlg.cs
+++ b/src/L10NSharp/UI/LocalizeItemDlg.cs
@@ -382,7 +382,10 @@ namespace L10NSharp.UI
 				_grid.EndEdit(DataGridViewDataErrorContexts.Commit);
 
 			if (_viewModel.Save())
-				FireStringsLocalizedEvent(_callingManager);
+			{
+				foreach (var manager in _viewModel.GetModifiedManagers())
+					FireStringsLocalizedEvent(manager);
+			}
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -885,7 +888,7 @@ namespace L10NSharp.UI
 
 		private void _howToDistribute_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
 		{
-			using(var dlg = new HowToDistributeDialog(LocalizationManager.EmailForSubmissions,
+			using (var dlg = new HowToDistributeDialog(LocalizationManager.EmailForSubmissions,
 				_callingManager.GetPathForLanguage(_viewModel.TgtLangId, true)))
 			{
 				dlg.ShowDialog();

--- a/src/SampleApp/Form1.Designer.cs
+++ b/src/SampleApp/Form1.Designer.cs
@@ -1,3 +1,4 @@
+using L10NSharp;
 using L10NSharp.XLiffUtils;
 
 namespace SampleApp
@@ -98,6 +99,7 @@ namespace SampleApp
 			this.uiLanguageComboBox1.IntegralHeight = false;
 			this.localizationExtender1.SetLocalizableToolTip(this.uiLanguageComboBox1, null);
 			this.localizationExtender1.SetLocalizationComment(this.uiLanguageComboBox1, null);
+			this.localizationExtender1.SetLocalizationPriority(this.uiLanguageComboBox1, LocalizationPriority.NotLocalizable);
 			this.localizationExtender1.SetLocalizingId(this.uiLanguageComboBox1, "uiLanguageComboBox1.uiLanguageComboBox1");
 			this.uiLanguageComboBox1.Location = new System.Drawing.Point(40, 41);
 			this.uiLanguageComboBox1.Name = "uiLanguageComboBox1";

--- a/src/SampleApp/Form1.cs
+++ b/src/SampleApp/Form1.cs
@@ -31,6 +31,7 @@ namespace SampleApp
 		private void linkLabel1_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
 		{
 			LocalizationManager.ShowLocalizationDialogBox(this);
+			uiLanguageComboBox1.RefreshList();
 			UpdateDynamicLabel();
 		}
 


### PR DESCRIPTION
When changes are made in the localization dialog, the StringsLocalized gets fired for all managers that have had their strings modified for the current UI language.
Also made a couple small improvements to the SampleApp so that is it more useful for testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/96)
<!-- Reviewable:end -->
