### PR TITLE
Allow caller to specify file extension of the "original" executable file in LocalizationManager.Create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ With the latest changes, this is required: the language name indicated in these 
 name must match the language declared in the target-language attribute, or at least match the
 first element of the target-language (e.g., a file with target-languge es-ES may be stored in
 file like Bloom.es.xlf or .../es/Bloom.xlf).
+- Progress dialogs are no longer shown when initializing XLIFF-based LocalizationManagers.
+- Made it possible for caller to specify the file extension of the "original" executable file
+when constructing an XLIFF-based LocalizationManager.
+- Changed the way the "original" attribute is set in XLIFF files. It used to be based on the
+Name, but changed it to use Id instead.
 
 ### Removed
 

--- a/src/L10NSharp/LocalizationManager.cs
+++ b/src/L10NSharp/LocalizationManager.cs
@@ -73,7 +73,10 @@ namespace L10NSharp
 		/// falls back to the default.</param>
 		/// <param name="appId">The application Id (e.g. 'Pa' for Phonology Assistant).
 		/// This should be a unique name that identifies the manager for an assembly or
-		/// application.</param>
+		/// application. May include an optional file extension, which will be stripped off but
+		/// used to correctly set the "original" attribute when persisting an XLIFF file. The
+		/// base portion must still be unique (i.e., it is not valid to create a LM for
+		/// "Blah.exe" and another for "Blah.dll").</param>
 		/// <param name="appName">The application's name. This will appear to the user
 		/// in the localization dialog box as a parent item in the tree.</param>
 		/// <param name="appVersion"></param>
@@ -114,7 +117,10 @@ namespace L10NSharp
 		/// falls back to the default.</param>
 		/// <param name="appId">The application Id (e.g. 'Pa' for Phonology Assistant).
 		/// This should be a unique name that identifies the manager for an assembly or
-		/// application.</param>
+		/// application. May include an optional file extension, which will be stripped off but
+		/// used to correctly set the "original" attribute when persisting an XLIFF file. The
+		/// base portion must still be unique (i.e., it is not valid to create a LM for
+		/// "Blah.exe" and another for "Blah.dll").</param>
 		/// <param name="appName">The application's name. This will appear to the user
 		/// in the localization dialog box as a parent item in the tree.</param>
 		/// <param name="appVersion"></param>
@@ -153,10 +159,9 @@ namespace L10NSharp
 			{
 				case TranslationMemory.Tmx:
 					return LocalizationManagerInternal<TMXDocument>.CreateTmx(desiredUiLangId,
-						appId, appName, appVersion, directoryOfInstalledFiles,
-						relativeSettingPathForLocalizationFolder, applicationIcon,
-						additionalLocalizationMethods,
-						namespaceBeginnings);
+						System.IO.Path.GetFileNameWithoutExtension(appId), appName, appVersion,
+						directoryOfInstalledFiles, relativeSettingPathForLocalizationFolder,
+						applicationIcon, additionalLocalizationMethods, namespaceBeginnings);
 				case TranslationMemory.XLiff:
 					return LocalizationManagerInternal<XLiffDocument>.CreateXliff(desiredUiLangId,
 						appId, appName, appVersion, directoryOfInstalledFiles,
@@ -175,7 +180,8 @@ namespace L10NSharp
 		/// instead of the common/shared AppData folder, applications can use this method to
 		/// purge old Xliff/Tmx files.</summary>
 		/// <param name="appId">ID of the application used for creating the Xliff/Tmx files
-		/// (typically the same ID passed as the 2nd parameter to LocalizationManagerInternal.Create).
+		/// (typically the same ID passed as the 2nd parameter to
+		/// LocalizationManagerInternal.Create, but without a file extension).
 		/// </param>
 		/// <param name="directoryOfWritableTranslationFiles">Folder from which to delete
 		/// Xliff/Tmx files.</param>

--- a/src/L10NSharp/LocalizationManagerInternal.cs
+++ b/src/L10NSharp/LocalizationManagerInternal.cs
@@ -165,7 +165,10 @@ namespace L10NSharp
 		/// falls back to the default.</param>
 		/// <param name="appId">The application Id (e.g. 'Pa' for Phonology Assistant).
 		/// This should be a unique name that identifies the manager for an assembly or
-		/// application.</param>
+		/// application. May include an optional file extension, which will be stripped off but
+		/// used to correctly set the "original" attribute when persisting an XLIFF file. The
+		/// base portion must still be unique (i.e., it is not valid to create a LM for
+		/// "Blah.exe" and another for "Blah.dll").</param>
 		/// <param name="appName">The application's name. This will appear to the user
 		/// in the localization dialog box as a parent item in the tree.</param>
 		/// <param name="appVersion"></param>
@@ -212,7 +215,8 @@ namespace L10NSharp
 		/// instead of the common/shared AppData folder, applications can use this method to
 		/// purge old Xliff files.</summary>
 		/// <param name="appId">ID of the application used for creating the Xliff files (typically
-		/// the same ID passed as the 2nd parameter to LocalizationManagerInternal.Create).</param>
+		/// the same ID passed as the 2nd parameter to LocalizationManagerInternal.Create, but
+		/// without a file extension).</param>
 		/// <param name="directoryOfWritableXliffFiles">Folder from which to delete Xliff files.
 		/// </param>
 		/// <param name="directoryOfInstalledXliffFiles">Used to limit file deletion to only

--- a/src/L10NSharp/XLiffUtils/XLiffLocalizedStringCache.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffLocalizedStringCache.cs
@@ -42,7 +42,7 @@ namespace L10NSharp.XLiffUtils
 		/// ------------------------------------------------------------------------------------
 		internal XLiffLocalizedStringCache(ILocalizationManager owningManager, bool loadAvailableXliffFiles = true)
 		{
-			OwningManager = owningManager as XLiffLocalizationManager;
+			OwningManager = (XLiffLocalizationManager)owningManager;
 			if (loadAvailableXliffFiles)
 			{
 				try
@@ -59,7 +59,7 @@ namespace L10NSharp.XLiffUtils
 			else
 			{
 				DefaultXliffDocument = CreateEmptyStringFile();
-				DefaultXliffDocument.File.Original = OwningManager.Name + ".dll";
+				DefaultXliffDocument.File.Original = OwningManager.OriginalExecutableFile;
 				XliffDocuments.TryAdd(LocalizationManager.kDefaultLang, DefaultXliffDocument);
 			}
 			_tuUpdater = new XLiffTransUnitUpdater(this);
@@ -363,8 +363,7 @@ namespace L10NSharp.XLiffUtils
 			xliffOutput.File.ProductVersion = OwningManager.AppVersion;
 			xliffOutput.File.HardLineBreakReplacement = s_literalNewline;
 			xliffOutput.File.AmpersandReplacement = _ampersandReplacement;
-			if (OwningManager != null && OwningManager.Name != null)
-				xliffOutput.File.Original = OwningManager.Name + ".dll";
+			xliffOutput.File.Original = OwningManager.OriginalExecutableFile;
 
 			foreach (var tu in DefaultXliffDocument.File.Body.TransUnitsUnordered)
 			{

--- a/src/L10NSharpTests/XLiffLocalizationManagerTests.cs
+++ b/src/L10NSharpTests/XLiffLocalizationManagerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 SIL International
+// Copyright (c) 2022 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Collections.Generic;
@@ -20,14 +20,16 @@ namespace L10NSharp.Tests
 		}
 
 		internal override ILocalizationManagerInternal<XLiffDocument> CreateLocalizationManager(
-			string          appId,                               string appName, string appVersion, string directoryOfInstalledTmxFiles,
-			string          directoryForGeneratedDefaultTmxFile, string directoryOfUserModifiedXliffFiles,
+			string appId, string appName, string appVersion, string directoryOfInstalledLocFiles,
+			string directoryForGeneratedDefaultFile, string directoryOfUserModifiedXliffFiles,
 			IEnumerable<MethodInfo> additionalGetStringMethodInfo = null,
 			params string[] namespaceBeginnings)
 		{
-			return new XLiffLocalizationManager(appId, appName, appVersion, directoryOfInstalledTmxFiles,
-				directoryForGeneratedDefaultTmxFile, directoryOfUserModifiedXliffFiles, additionalGetStringMethodInfo,
+			var manager = new XLiffLocalizationManager(appId, appName, appVersion, directoryOfInstalledLocFiles,
+				directoryForGeneratedDefaultFile, directoryOfUserModifiedXliffFiles, additionalGetStringMethodInfo,
 				namespaceBeginnings);
+			Assert.That(manager.OriginalExecutableFile, Is.EqualTo(appId + ".dll"));
+			return manager;
 		}
 
 		internal override ILocalizationManagerInternal<XLiffDocument> CreateLocalizationManager(


### PR DESCRIPTION
Also, changed to use Id rather than Name to generate the "original" attribute in XLIFF files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/97)
<!-- Reviewable:end -->
