### PR TITLE
Add `LocalizationManager.Create` methods without `kind` parameter

### DIFF
--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install .NET Core
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # v2.1.0
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
 
     - name: Build and Pack
       run: dotnet build --configuration Release

--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -44,7 +44,8 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
 
     - name: Test (Windows)
-      run: dotnet test --configuration Release --no-build -- NUnit.TestOutputXml=TestResults
+      # specify path to test assembly as workaround for https://github.com/nunit/nunit3-vs-adapter/issues/1040
+      run: dotnet test --configuration Release --no-build output\Release\net461\*Tests.dll -- NUnit.TestOutputXml=TestResults
       if: matrix.os != 'ubuntu-latest'
 
     - name: Upload Test Results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `LocalizationManager.Create` methods without `TranslationMemory kind` parameter
+
+### Deprecated
+
+- `LocalizationManager.Create` methods with `TranslationMemory kind` parameter
+
 ## [6.0.0] - 2022-11-21
 
 ### Changed

--- a/L10NSharp.sln
+++ b/L10NSharp.sln
@@ -20,6 +20,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionFolder", "SolutionF
 		CHANGELOG.md = CHANGELOG.md
 		GitVersion.yml = GitVersion.yml
 		README.md = README.md
+		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
 	EndProjectSection
 EndProject
 Global

--- a/src/CheckOrFixXliff/CheckOrFixXliff.csproj
+++ b/src/CheckOrFixXliff/CheckOrFixXliff.csproj
@@ -7,8 +7,9 @@
     <AssemblyTitle>CheckOrFixXliff</AssemblyTitle>
     <PackageId>L10NSharp.CheckOrFixXliff</PackageId>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-	<PackageProjectUrl>https://github.com/sillsdev/l10nsharp/tree/master/src/CheckOrFixXliff</PackageProjectUrl>
-	<TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
+    <PackageProjectUrl>https://github.com/sillsdev/l10nsharp/tree/master/src/CheckOrFixXliff</PackageProjectUrl>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.ServiceModel" />

--- a/src/CheckOrFixXliff/CheckOrFixXliff.csproj
+++ b/src/CheckOrFixXliff/CheckOrFixXliff.csproj
@@ -16,7 +16,7 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="all" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.11.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
   </ItemGroup>

--- a/src/ExtractXliff/ExtractXliff.csproj
+++ b/src/ExtractXliff/ExtractXliff.csproj
@@ -16,7 +16,7 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="all" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.11.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
   </ItemGroup>

--- a/src/ExtractXliff/ExtractXliff.csproj
+++ b/src/ExtractXliff/ExtractXliff.csproj
@@ -9,6 +9,7 @@
     <PackageId>L10NSharp.ExtractXliff</PackageId>
     <PackageProjectUrl>https://github.com/sillsdev/l10nsharp/tree/master/src/ExtractXliff</PackageProjectUrl>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.ServiceModel" />

--- a/src/L10NSharp/L10NSharp.csproj
+++ b/src/L10NSharp/L10NSharp.csproj
@@ -11,7 +11,7 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="all" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.11.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
     <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />

--- a/src/L10NSharp/LocalizationManager.cs
+++ b/src/L10NSharp/LocalizationManager.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
 using System.IO;
@@ -94,6 +95,7 @@ namespace L10NSharp
 		/// types found in Pa.exe and assuming all types in that assembly begin with
 		/// 'Pa', then this value would only contain the string 'Pa'.</param>
 		/// ------------------------------------------------------------------------------------
+		[Obsolete("Use the overload without `TranslationMemory kind` parameter.")]
 		public static ILocalizationManager Create(TranslationMemory kind, string desiredUiLangId,
 			string appId, string appName, string appVersion, string directoryOfInstalledFiles,
 			string relativeSettingPathForLocalizationFolder,
@@ -147,6 +149,7 @@ namespace L10NSharp
 		/// types found in Pa.exe and assuming all types in that assembly begin with
 		/// 'Pa', then this value would only contain the string 'Pa'.</param>
 		/// ------------------------------------------------------------------------------------
+		[Obsolete("Use the overload without `TranslationMemory kind` parameter.")]
 		public static ILocalizationManager Create(TranslationMemory kind, string desiredUiLangId,
 			string appId, string appName, string appVersion, string directoryOfInstalledFiles,
 			string relativeSettingPathForLocalizationFolder,
@@ -154,20 +157,115 @@ namespace L10NSharp
 			IEnumerable<MethodInfo> additionalLocalizationMethods,
 			params string[] namespaceBeginnings)
 		{
-			TranslationMemoryKind = kind;
-			EmailForSubmissions = emailForSubmissions;
-			switch (kind)
+			if (kind != TranslationMemory.XLiff)
 			{
-				case TranslationMemory.XLiff:
-					return LocalizationManagerInternal<XLiffDocument>.CreateXliff(desiredUiLangId,
-						appId, appName, appVersion, directoryOfInstalledFiles,
-						relativeSettingPathForLocalizationFolder, applicationIcon,
-						additionalLocalizationMethods,
-						namespaceBeginnings);
-				default:
-					throw new ArgumentException($"Unknown translation memory kind {TranslationMemoryKind}",
-						nameof(kind));
+				throw new ArgumentException($@"Unknown translation memory kind {kind}. Only XLiff
+				 is supported.",
+					nameof(kind));
 			}
+
+			return Create(desiredUiLangId, appId, appName, appVersion, directoryOfInstalledFiles,
+				relativeSettingPathForLocalizationFolder, applicationIcon, emailForSubmissions,
+				additionalLocalizationMethods, namespaceBeginnings);
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Creates a new instance of a localization manager for the specified application id.
+		/// If a localization manager has already been created for the specified id, then
+		/// that is returned.
+		/// </summary>
+		/// <param name="desiredUiLangId">The language code of the desired UI language. If
+		/// there are no translations for that ID, a message is displayed and the UI language
+		/// falls back to the default.</param>
+		/// <param name="appId">The application Id (e.g. 'Pa' for Phonology Assistant).
+		/// This should be a unique name that identifies the manager for an assembly or
+		/// application. May include an optional file extension, which will be stripped off but
+		/// used to correctly set the "original" attribute when persisting an XLIFF file. The
+		/// base portion must still be unique (i.e., it is not valid to create a LM for
+		/// "Blah.exe" and another for "Blah.dll").</param>
+		/// <param name="appName">The application's name. This will appear to the user
+		/// in the localization dialog box as a parent item in the tree.</param>
+		/// <param name="appVersion"></param>
+		/// <param name="directoryOfInstalledFiles">The full folder path of the original l10n
+		/// files installed with the application.</param>
+		/// <param name="relativeSettingPathForLocalizationFolder">The path, relative to
+		/// %appdata%, where your application stores user settings (e.g., "SIL\SayMore").
+		/// A folder named "localizations" will be created there.</param>
+		/// <param name="applicationIcon"> </param>
+		/// <param name="emailForSubmissions">This will be used in UI that helps the translator
+		/// know what to do with their work</param>
+		/// <param name="namespaceBeginnings">A list of namespace beginnings indicating
+		/// what types to scan for localized string calls. For example, to only scan
+		/// types found in Pa.exe and assuming all types in that assembly begin with
+		/// 'Pa', then this value would only contain the string 'Pa'.</param>
+		/// ------------------------------------------------------------------------------------
+		public static ILocalizationManager Create(string desiredUiLangId,
+			string appId, string appName, string appVersion, string directoryOfInstalledFiles,
+			string relativeSettingPathForLocalizationFolder,
+			Icon applicationIcon, string emailForSubmissions, params string[] namespaceBeginnings)
+		{
+			return Create(desiredUiLangId,
+				appId, appName, appVersion, directoryOfInstalledFiles,
+				relativeSettingPathForLocalizationFolder,
+				applicationIcon, emailForSubmissions,
+				null, namespaceBeginnings);
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Creates a new instance of a localization manager for the specified application id.
+		/// If a localization manager has already been created for the specified id, then
+		/// that is returned.
+		/// </summary>
+		/// <param name="desiredUiLangId">The language code of the desired UI language. If
+		/// there are no translations for that ID, a message is displayed and the UI language
+		/// falls back to the default.</param>
+		/// <param name="appId">The application Id (e.g. 'Pa' for Phonology Assistant).
+		/// This should be a unique name that identifies the manager for an assembly or
+		/// application. May include an optional file extension, which will be stripped off but
+		/// used to correctly set the "original" attribute when persisting an XLIFF file. The
+		/// base portion must still be unique (i.e., it is not valid to create a LM for
+		/// "Blah.exe" and another for "Blah.dll").</param>
+		/// <param name="appName">The application's name. This will appear to the user
+		/// in the localization dialog box as a parent item in the tree.</param>
+		/// <param name="appVersion"></param>
+		/// <param name="directoryOfInstalledFiles">The full folder path of the original l10n
+		/// files installed with the application.</param>
+		/// <param name="relativeSettingPathForLocalizationFolder">The path, relative to
+		/// %appdata%, where your application stores user settings (e.g., "SIL\SayMore").
+		/// A folder named "localizations" will be created there.</param>
+		/// <param name="applicationIcon"> </param>
+		/// <param name="emailForSubmissions">This will be used in UI that helps the translator
+		/// know what to do with their work</param>
+		/// <param name="additionalLocalizationMethods">MethodInfo objects representing
+		/// additional methods that should be regarded as calls to get localizations. If the method
+		/// is named "Localize", the extractor will attempt to parse its signature as an extension
+		/// method with the parameters (this string s, string separateId="", string comment="").
+		/// Otherwise, it will be treated like a L10nSharp GetString method if its signature
+		/// matches one of the following: (string stringId, string englishText),
+		/// (string stringId, string englishText, string comment), or
+		/// (string stringId, string englishText, string comment, string englishToolTipText,
+		/// string englishShortcutKey, IComponent component).</param>
+		/// <param name="namespaceBeginnings">A list of namespace beginnings indicating
+		/// what types to scan for localized string calls. For example, to only scan
+		/// types found in Pa.exe and assuming all types in that assembly begin with
+		/// 'Pa', then this value would only contain the string 'Pa'.</param>
+		/// ------------------------------------------------------------------------------------
+		public static ILocalizationManager Create(string desiredUiLangId,
+			string appId, string appName, string appVersion, string directoryOfInstalledFiles,
+			string relativeSettingPathForLocalizationFolder,
+			Icon applicationIcon, string emailForSubmissions,
+			IEnumerable<MethodInfo> additionalLocalizationMethods,
+			params string[] namespaceBeginnings)
+		{
+			TranslationMemoryKind = TranslationMemory.XLiff;
+			EmailForSubmissions = emailForSubmissions;
+			return LocalizationManagerInternal<XLiffDocument>.CreateXliff(desiredUiLangId,
+				appId, appName, appVersion, directoryOfInstalledFiles,
+				relativeSettingPathForLocalizationFolder, applicationIcon,
+				additionalLocalizationMethods,
+				namespaceBeginnings);
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/src/L10NSharp/LocalizationManager.cs
+++ b/src/L10NSharp/LocalizationManager.cs
@@ -105,7 +105,7 @@ namespace L10NSharp
 				appId, appName, appVersion, directoryOfInstalledFiles,
 				relativeSettingPathForLocalizationFolder,
 				applicationIcon, emailForSubmissions,
-				null, namespaceBeginnings);
+				namespaceBeginnings);
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -166,7 +166,7 @@ namespace L10NSharp
 
 			return Create(desiredUiLangId, appId, appName, appVersion, directoryOfInstalledFiles,
 				relativeSettingPathForLocalizationFolder, applicationIcon, emailForSubmissions,
-				additionalLocalizationMethods, namespaceBeginnings);
+				namespaceBeginnings, additionalLocalizationMethods);
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -190,7 +190,7 @@ namespace L10NSharp
 		/// <param name="directoryOfInstalledFiles">The full folder path of the original l10n
 		/// files installed with the application.</param>
 		/// <param name="relativeSettingPathForLocalizationFolder">The path, relative to
-		/// %appdata%, where your application stores user settings (e.g., "SIL\SayMore").
+		/// %localappdata%, where your application stores user settings (e.g., "SIL\SayMore").
 		/// A folder named "localizations" will be created there.</param>
 		/// <param name="applicationIcon"> </param>
 		/// <param name="emailForSubmissions">This will be used in UI that helps the translator
@@ -199,45 +199,6 @@ namespace L10NSharp
 		/// what types to scan for localized string calls. For example, to only scan
 		/// types found in Pa.exe and assuming all types in that assembly begin with
 		/// 'Pa', then this value would only contain the string 'Pa'.</param>
-		/// ------------------------------------------------------------------------------------
-		public static ILocalizationManager Create(string desiredUiLangId,
-			string appId, string appName, string appVersion, string directoryOfInstalledFiles,
-			string relativeSettingPathForLocalizationFolder,
-			Icon applicationIcon, string emailForSubmissions, params string[] namespaceBeginnings)
-		{
-			return Create(desiredUiLangId,
-				appId, appName, appVersion, directoryOfInstalledFiles,
-				relativeSettingPathForLocalizationFolder,
-				applicationIcon, emailForSubmissions,
-				null, namespaceBeginnings);
-		}
-
-		/// ------------------------------------------------------------------------------------
-		/// <summary>
-		/// Creates a new instance of a localization manager for the specified application id.
-		/// If a localization manager has already been created for the specified id, then
-		/// that is returned.
-		/// </summary>
-		/// <param name="desiredUiLangId">The language code of the desired UI language. If
-		/// there are no translations for that ID, a message is displayed and the UI language
-		/// falls back to the default.</param>
-		/// <param name="appId">The application Id (e.g. 'Pa' for Phonology Assistant).
-		/// This should be a unique name that identifies the manager for an assembly or
-		/// application. May include an optional file extension, which will be stripped off but
-		/// used to correctly set the "original" attribute when persisting an XLIFF file. The
-		/// base portion must still be unique (i.e., it is not valid to create a LM for
-		/// "Blah.exe" and another for "Blah.dll").</param>
-		/// <param name="appName">The application's name. This will appear to the user
-		/// in the localization dialog box as a parent item in the tree.</param>
-		/// <param name="appVersion"></param>
-		/// <param name="directoryOfInstalledFiles">The full folder path of the original l10n
-		/// files installed with the application.</param>
-		/// <param name="relativeSettingPathForLocalizationFolder">The path, relative to
-		/// %appdata%, where your application stores user settings (e.g., "SIL\SayMore").
-		/// A folder named "localizations" will be created there.</param>
-		/// <param name="applicationIcon"> </param>
-		/// <param name="emailForSubmissions">This will be used in UI that helps the translator
-		/// know what to do with their work</param>
 		/// <param name="additionalLocalizationMethods">MethodInfo objects representing
 		/// additional methods that should be regarded as calls to get localizations. If the method
 		/// is named "Localize", the extractor will attempt to parse its signature as an extension
@@ -247,17 +208,13 @@ namespace L10NSharp
 		/// (string stringId, string englishText, string comment), or
 		/// (string stringId, string englishText, string comment, string englishToolTipText,
 		/// string englishShortcutKey, IComponent component).</param>
-		/// <param name="namespaceBeginnings">A list of namespace beginnings indicating
-		/// what types to scan for localized string calls. For example, to only scan
-		/// types found in Pa.exe and assuming all types in that assembly begin with
-		/// 'Pa', then this value would only contain the string 'Pa'.</param>
 		/// ------------------------------------------------------------------------------------
 		public static ILocalizationManager Create(string desiredUiLangId,
 			string appId, string appName, string appVersion, string directoryOfInstalledFiles,
 			string relativeSettingPathForLocalizationFolder,
 			Icon applicationIcon, string emailForSubmissions,
-			IEnumerable<MethodInfo> additionalLocalizationMethods,
-			params string[] namespaceBeginnings)
+			string[] namespaceBeginnings,
+			IEnumerable<MethodInfo> additionalLocalizationMethods = null)
 		{
 			TranslationMemoryKind = TranslationMemory.XLiff;
 			EmailForSubmissions = emailForSubmissions;

--- a/src/L10NSharpTests/ILocalizableComponentTests.cs
+++ b/src/L10NSharpTests/ILocalizableComponentTests.cs
@@ -30,7 +30,7 @@ namespace L10NSharp.Tests
 			var dir = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
 			m_manager = LocalizationManager.Create("en", "Test", "Test", "1.0",
 					Path.Combine(dir, installedTranslationDir),
-					"", null, "")
+					"", null, "", new string[] {  })
 				as ILocalizationManagerInternal<XLiffDocument>;
 			m_translationPath = m_manager.GetPathForLanguage("en", true);
 			m_extender = new L10NSharpExtender { LocalizationManagerId = "Test" };

--- a/src/L10NSharpTests/ILocalizableComponentTests.cs
+++ b/src/L10NSharpTests/ILocalizableComponentTests.cs
@@ -25,10 +25,10 @@ namespace L10NSharp.Tests
 		/// Setup for each test.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		protected void TestSetup(TranslationMemory kind, string installedTranslationDir)
+		protected void TestSetup(string installedTranslationDir)
 		{
 			var dir = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
-			m_manager = LocalizationManager.Create(kind, "en", "Test", "Test", "1.0",
+			m_manager = LocalizationManager.Create("en", "Test", "Test", "1.0",
 					Path.Combine(dir, installedTranslationDir),
 					"", null, "")
 				as ILocalizationManagerInternal<XLiffDocument>;
@@ -39,7 +39,7 @@ namespace L10NSharp.Tests
 		[SetUp]
 		public void TestSetup()
 		{
-			TestSetup(TranslationMemory.XLiff, "../../../src/L10NSharpTests/TestXliff");
+			TestSetup("../../../src/L10NSharpTests/TestXliff");
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/src/L10NSharpTests/L10NSharpTests.csproj
+++ b/src/L10NSharpTests/L10NSharpTests.csproj
@@ -9,9 +9,9 @@
 	  <ProjectReference Include="..\L10NSharp\L10NSharp.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
 	  <PackageReference Include="NUnit" Version="3.13.3" />
-	  <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+	  <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
 	</ItemGroup>
 	<ItemGroup>
 	  <Reference Include="System.Windows.Forms" />

--- a/src/L10NSharpTests/LocalizationManagerXliffTests.cs
+++ b/src/L10NSharpTests/LocalizationManagerXliffTests.cs
@@ -39,7 +39,7 @@ namespace L10NSharp.Tests
 		{
 			LocalizationManager.ClearLoadedManagers();
 			var dir = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
-			var lm = LocalizationManager.Create(TranslationMemory.XLiff, genericLocaleId, "Test", "Test", "1.0",
+			var lm = LocalizationManager.Create(genericLocaleId, "Test", "Test", "1.0",
 				Path.Combine(dir, "../../../src/L10NSharpTests/TestXliff2"), "", null, "");
 			Assert.AreEqual($"Protección de configuraciones ({genericLocaleId})...",
 				lm.GetLocalizedString("SettingsProtection.LauncherButtonLabel", "don't use this"));

--- a/src/L10NSharpTests/LocalizationManagerXliffTests.cs
+++ b/src/L10NSharpTests/LocalizationManagerXliffTests.cs
@@ -40,7 +40,8 @@ namespace L10NSharp.Tests
 			LocalizationManager.ClearLoadedManagers();
 			var dir = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
 			var lm = LocalizationManager.Create(genericLocaleId, "Test", "Test", "1.0",
-				Path.Combine(dir, "../../../src/L10NSharpTests/TestXliff2"), "", null, "");
+				Path.Combine(dir, "../../../src/L10NSharpTests/TestXliff2"), "", null, "",
+				new string[] {});
 			Assert.AreEqual($"Protección de configuraciones ({genericLocaleId})...",
 				lm.GetLocalizedString("SettingsProtection.LauncherButtonLabel", "don't use this"));
 			// The next two lines prove that the test data was not changed in a way that nullifies the expected pre-conditions

--- a/src/SampleApp/Program.cs
+++ b/src/SampleApp/Program.cs
@@ -61,10 +61,10 @@ namespace SampleApp
 						"MyCompany/L10NSharpSample",
 						Resources.Icon, //replace with your icon
 						"sampleappLocalizations@nowhere.com",
+						new[] { "SampleApp" },
 						typeof(Program)
 							.GetMethods(BindingFlags.Static | BindingFlags.Public)
-							.Where(m => m.Name == "MyOwnGetString"),
-						"SampleApp");
+							.Where(m => m.Name == "MyOwnGetString"));
 				}
 				else
 				{
@@ -73,7 +73,8 @@ namespace SampleApp
 						directoryOfInstalledLocFiles,
 						"MyCompany/L10NSharpSample",
 						Resources.Icon, //replace with your icon
-						"sampleappLocalizations@nowhere.com", "SampleApp");
+						"sampleappLocalizations@nowhere.com",
+						new[] { "SampleApp" });
 				}
 
 				Settings.Default.UserInterfaceLanguage = LocalizationManager.UILanguageId;

--- a/src/SampleApp/Program.cs
+++ b/src/SampleApp/Program.cs
@@ -49,16 +49,13 @@ namespace SampleApp
 
 				var theLanguageYouRememberedFromLastTime = Settings.Default.UserInterfaceLanguage;
 
-				var translationMemoryType = TranslationMemory.XLiff;
-
 				if (useAdditionalMethodInfo)
 				{
 					MessageBox.Show(MyOwnGetString("SampleApp.InformationalMessageBox.Message",
 							"The generated localization file should contain this string and the window title.", "This is a comment"),
 						MyOwnGetString("SampleApp.InformationalMessageBox.Title", "Cool Title"));
 
-					_localizationManager = LocalizationManager.Create(translationMemoryType,
-						theLanguageYouRememberedFromLastTime,
+					_localizationManager = LocalizationManager.Create(theLanguageYouRememberedFromLastTime,
 						"SampleApp.exe", "SampleApp", Application.ProductVersion,
 						directoryOfInstalledLocFiles,
 						"MyCompany/L10NSharpSample",
@@ -71,8 +68,7 @@ namespace SampleApp
 				}
 				else
 				{
-					_localizationManager = LocalizationManager.Create(translationMemoryType,
-						theLanguageYouRememberedFromLastTime,
+					_localizationManager = LocalizationManager.Create(theLanguageYouRememberedFromLastTime,
 						"SampleApp.exe", "SampleApp", Application.ProductVersion,
 						directoryOfInstalledLocFiles,
 						"MyCompany/L10NSharpSample",


### PR DESCRIPTION
Also deprecate existing `Create` methods with `kind` parameter. 

Since `Xliff` is now the only supported translation memory, the `kind` parameter is unnecessary. This change adds new overloads without the `kind` parameter and marks the existing methods as `Obsolete`. 

+semver:minor

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/107)
<!-- Reviewable:end -->
