### PR TITLE
Fix capitalization on internal XliffUtils classes

### DIFF
--- a/src/ExtractXliff/Program.cs
+++ b/src/ExtractXliff/Program.cs
@@ -120,7 +120,7 @@ namespace ExtractXliff
 			// L10NSharp for reasons that may not percolate out to xliff. We just need a LocalizationManagerInternal
 			// to feed into the constructor the LocalizedStringCache that does some heavy lifting for us in
 			// creating the XliffDocument from the newly extracted localized strings.
-			var lm = new XLiffLocalizationManager(_fileOriginal, _fileOriginal, _fileProductVersion);
+			var lm = new XliffLocalizationManager(_fileOriginal, _fileOriginal, _fileProductVersion);
 			var stringCache = new XliffLocalizedStringCache(lm, false);
 			foreach (var locInfo in localizedStrings)
 				stringCache.UpdateLocalizedInfo(locInfo);
@@ -130,7 +130,7 @@ namespace ExtractXliff
 			var baseDoc = LoadBaselineAndCompare(newDoc);
 
 			// Save the results to the output file, merging in data from the baseline XLIFF if one was specified.
-			var xliffOutput = XLiffLocalizationManager.MergeXliffDocuments(newDoc, baseDoc, _verbose);
+			var xliffOutput = XliffLocalizationManager.MergeXliffDocuments(newDoc, baseDoc, _verbose);
 			xliffOutput.File.SourceLang = kDefaultLangId;
 			xliffOutput.File.ProductVersion = !string.IsNullOrEmpty(_fileProductVersion) ? _fileProductVersion : newDoc.File.ProductVersion;
 			xliffOutput.File.HardLineBreakReplacement = kDefaultNewlineReplacement;

--- a/src/L10NSharp/LocalizationManager.cs
+++ b/src/L10NSharp/LocalizationManager.cs
@@ -262,7 +262,7 @@ namespace L10NSharp
 			}
 			else
 			{
-				XLiffLocalizationManager.DeleteOldXliffFiles(appId,
+				XliffLocalizationManager.DeleteOldXliffFiles(appId,
 					directoryOfWritableTranslationFiles,
 					directoryOfInstalledTranslationFiles);
 			}
@@ -714,7 +714,7 @@ namespace L10NSharp
 			{
 				default:
 				case TranslationMemory.XLiff:
-					fileExtension = XLiffLocalizationManager.FileExtension;
+					fileExtension = XliffLocalizationManager.FileExtension;
 					break;
 			}
 			return GetTranslationFileNameForLanguage(appId, langId, fileExtension);

--- a/src/L10NSharp/LocalizationManagerInternal.cs
+++ b/src/L10NSharp/LocalizationManagerInternal.cs
@@ -168,7 +168,7 @@ namespace L10NSharp
 			return Create(desiredUiLangId, appId, appName,
 				relativeSettingPathForLocalizationFolder, applicationIcon,
 				directoryOfWritableXliffFiles =>
-					(ILocalizationManagerInternal<T>) new XLiffLocalizationManager(appId, origExeExtension, appName,
+					(ILocalizationManagerInternal<T>) new XliffLocalizationManager(appId, origExeExtension, appName,
 						appVersion, directoryOfInstalledXliffFiles,
 						directoryOfWritableXliffFiles, directoryOfWritableXliffFiles,
 						additionalLocalizationMethods,

--- a/src/L10NSharp/XLiffUtils/XLiffDocument.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffDocument.cs
@@ -122,7 +122,7 @@ namespace L10NSharp.XLiffUtils
 			{
 				try
 				{
-					XLiffXmlSerializationHelper.SerializeToFile(xliffFile, this);
+					XliffXmlSerializationHelper.SerializeToFile(xliffFile, this);
 					return;
 				}
 				catch (IOException)
@@ -153,7 +153,7 @@ namespace L10NSharp.XLiffUtils
 
 			Exception e;
 			var xLiffDoc =
-				XLiffXmlSerializationHelper.DeserializeFromFile<XLiffDocument>(xLiffFile, out e);
+				XliffXmlSerializationHelper.DeserializeFromFile<XLiffDocument>(xLiffFile, out e);
 
 			if (e != null)
 				throw e;

--- a/src/L10NSharp/XLiffUtils/XLiffFile.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffFile.cs
@@ -113,7 +113,7 @@ namespace L10NSharp.XLiffUtils
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[XmlAttribute("hard-linebreak-replacement", Namespace =
-			XLiffXmlSerializationHelper.kSilNamespace),
+			XliffXmlSerializationHelper.kSilNamespace),
 		DefaultValue(LocalizedStringCache.kDefaultNewlineReplacement)]
 		public string HardLineBreakReplacement { get; set; }
 
@@ -125,7 +125,7 @@ namespace L10NSharp.XLiffUtils
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[XmlAttribute("ampersand-replacement", Namespace =
-			XLiffXmlSerializationHelper.kSilNamespace),
+			XliffXmlSerializationHelper.kSilNamespace),
 		DefaultValue(LocalizedStringCache.kDefaultAmpersandReplacement)]
 		public string AmpersandReplacement { get; set; }
 

--- a/src/L10NSharp/XLiffUtils/XLiffTransUnit.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffTransUnit.cs
@@ -53,7 +53,7 @@ namespace L10NSharp.XLiffUtils
 		/// Gets whether the unit is "dynamic" (discovered dynamically while the program is running).
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		[XmlAttribute("dynamic", Namespace = XLiffXmlSerializationHelper.kSilNamespace),
+		[XmlAttribute("dynamic", Namespace = XliffXmlSerializationHelper.kSilNamespace),
 		System.ComponentModel.DefaultValue(false)]
 		public bool Dynamic { get; set; }
 
@@ -94,7 +94,7 @@ namespace L10NSharp.XLiffUtils
 		/// </summary>
 		/// <remarks>This appears to not be used in the Bloom files.</remarks>
 		/// ------------------------------------------------------------------------------------
-		[XmlAttribute("priority", Namespace = XLiffXmlSerializationHelper.kSilNamespace)]
+		[XmlAttribute("priority", Namespace = XliffXmlSerializationHelper.kSilNamespace)]
 		public string Priority { get; set; }
 
 		/// ------------------------------------------------------------------------------------
@@ -104,7 +104,7 @@ namespace L10NSharp.XLiffUtils
 		/// </summary>
 		/// <remarks>This appears to not be used in the Bloom files.</remarks>
 		/// ------------------------------------------------------------------------------------
-		[XmlAttribute("group", Namespace = XLiffXmlSerializationHelper.kSilNamespace)]
+		[XmlAttribute("group", Namespace = XliffXmlSerializationHelper.kSilNamespace)]
 		public string Group { get; set; }
 
 		/// ------------------------------------------------------------------------------------
@@ -116,7 +116,7 @@ namespace L10NSharp.XLiffUtils
 		/// </summary>
 		/// <remarks>This appears to not be used in the Bloom files.</remarks>
 		/// ------------------------------------------------------------------------------------
-		[XmlAttribute("category", Namespace = XLiffXmlSerializationHelper.kSilNamespace)]
+		[XmlAttribute("category", Namespace = XliffXmlSerializationHelper.kSilNamespace)]
 		public string Category { get; set; }
 
 		/// ------------------------------------------------------------------------------------

--- a/src/L10NSharp/XLiffUtils/XLiffTransUnitVariant.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffTransUnitVariant.cs
@@ -115,7 +115,7 @@ namespace L10NSharp.XLiffUtils
 
 				if (!string.IsNullOrEmpty(_deserializedFromElement))
 				{
-					// See the extended comment in  XLiffXmlSerializationHelper.deserializer_UnknownElement()
+					// See the extended comment in  XliffXmlSerializationHelper.deserializer_UnknownElement()
 					// to explain better why this code is needed.
 					if (_value == null)
 						_value =

--- a/src/L10NSharp/XLiffUtils/XliffLocalizationManager.cs
+++ b/src/L10NSharp/XLiffUtils/XliffLocalizationManager.cs
@@ -16,7 +16,7 @@ using L10NSharp.UI;
 namespace L10NSharp.XLiffUtils
 {
 	/// ----------------------------------------------------------------------------------------
-	internal class XLiffLocalizationManager : ILocalizationManagerInternal<XLiffDocument>
+	internal class XliffLocalizationManager : ILocalizationManagerInternal<XLiffDocument>
 	{
 		/// ------------------------------------------------------------------------------------
 		public const string FileExtension = ".xlf";
@@ -83,9 +83,9 @@ namespace L10NSharp.XLiffUtils
 
 		#endregion
 
-		#region XLiffLocalizationManager construction/disposal
+		#region XliffLocalizationManager construction/disposal
 		/// ------------------------------------------------------------------------------------
-		internal XLiffLocalizationManager(string appId, string origExtension, string appName,
+		internal XliffLocalizationManager(string appId, string origExtension, string appName,
 			string appVersion, string directoryOfInstalledXliffFiles,
 			string directoryForGeneratedDefaultXliffFile, string directoryOfUserModifiedXliffFiles,
 			IEnumerable<MethodInfo> additionalLocalizationMethods,
@@ -142,7 +142,7 @@ namespace L10NSharp.XLiffUtils
 		}
 
 		/// <summary>
-		/// Minimal constructor for a new instance of the <see cref="XLiffLocalizationManager"/> class.
+		/// Minimal constructor for a new instance of the <see cref="XliffLocalizationManager"/> class.
 		/// </summary>
 		/// <param name="appId">
 		/// The application Id (e.g. 'Pa' for Phonology Assistant). This should be a unique name that
@@ -155,7 +155,7 @@ namespace L10NSharp.XLiffUtils
 		/// <param name="appVersion">
 		/// The application's version.
 		/// </param>
-		internal XLiffLocalizationManager(string appId, string appName, string appVersion)
+		internal XliffLocalizationManager(string appId, string appName, string appVersion)
 		{
 			Id = appId;
 			Name = appName;

--- a/src/L10NSharp/XLiffUtils/XliffLocalizedStringCache.cs
+++ b/src/L10NSharp/XLiffUtils/XliffLocalizedStringCache.cs
@@ -15,10 +15,10 @@ namespace L10NSharp.XLiffUtils
 	/// ----------------------------------------------------------------------------------------
 	internal class XliffLocalizedStringCache : LocalizedStringCache, ILocalizedStringCache<XLiffDocument>
 	{
-		private readonly XLiffTransUnitUpdater _tuUpdater;
+		private readonly XliffTransUnitUpdater _tuUpdater;
 
 		public List<LocTreeNode<XLiffDocument>> LeafNodeList { get; private set; }
-		internal XLiffLocalizationManager OwningManager { get; private set; }
+		internal XliffLocalizationManager OwningManager { get; private set; }
 		private XLiffDocument DefaultXliffDocument { get; set; } // matches LanguageManager.kDefaultLanguage
 
 		/// <summary>
@@ -42,7 +42,7 @@ namespace L10NSharp.XLiffUtils
 		/// ------------------------------------------------------------------------------------
 		internal XliffLocalizedStringCache(ILocalizationManager owningManager, bool loadAvailableXliffFiles = true)
 		{
-			OwningManager = (XLiffLocalizationManager)owningManager;
+			OwningManager = (XliffLocalizationManager)owningManager;
 			if (loadAvailableXliffFiles)
 			{
 				try
@@ -62,7 +62,7 @@ namespace L10NSharp.XLiffUtils
 				DefaultXliffDocument.File.Original = OwningManager.OriginalExecutableFile;
 				XliffDocuments.TryAdd(LocalizationManager.kDefaultLang, DefaultXliffDocument);
 			}
-			_tuUpdater = new XLiffTransUnitUpdater(this);
+			_tuUpdater = new XliffTransUnitUpdater(this);
 
 			var replacement = DefaultXliffDocument.File.AmpersandReplacement;
 			if (replacement != null)
@@ -134,7 +134,7 @@ namespace L10NSharp.XLiffUtils
 			// (b) any newly obsolete IDs are noted.
 			if (File.Exists(OwningManager.DefaultInstalledStringFilePath))
 			{
-				if (!XLiffLocalizationManager.ScanningForCurrentStrings)
+				if (!XliffLocalizationManager.ScanningForCurrentStrings)
 				{
 					var defaultInstalledXliffDoc = XLiffDocument.Read(OwningManager.DefaultInstalledStringFilePath);
 					foreach (var tu in defaultInstalledXliffDoc.File.Body.TransUnitsUnordered)
@@ -150,7 +150,7 @@ namespace L10NSharp.XLiffUtils
 
 			foreach (var file in xliffFiles)
 			{
-				var langId = XLiffLocalizationManager.GetLangIdFromXliffFileName(file);
+				var langId = XliffLocalizationManager.GetLangIdFromXliffFileName(file);
 				Debug.Assert(!string.IsNullOrEmpty(langId));
 				Debug.Assert(langId != LocalizationManager.kDefaultLang);
 				_unloadedXliffDocuments[langId] = file;

--- a/src/L10NSharp/XLiffUtils/XliffTransUnitUpdater.cs
+++ b/src/L10NSharp/XLiffUtils/XliffTransUnitUpdater.cs
@@ -5,7 +5,7 @@ using L10NSharp.XLiffUtils;
 
 namespace L10NSharp.XLiffUtils
 {
-	internal class XLiffTransUnitUpdater
+	internal class XliffTransUnitUpdater
 	{
 		internal const string kToolTipSuffix  = "_ToolTip_";
 		internal const string kShortcutSuffix = "_ShortcutKeys_";
@@ -25,7 +25,7 @@ namespace L10NSharp.XLiffUtils
 
 
 		/// ------------------------------------------------------------------------------------
-		internal XLiffTransUnitUpdater(XliffLocalizedStringCache cache)
+		internal XliffTransUnitUpdater(XliffLocalizedStringCache cache)
 		{
 			_stringCache = cache;
 			_defaultLang = LocalizationManager.kDefaultLang;

--- a/src/L10NSharp/XLiffUtils/XliffXmlSerializationHelper.cs
+++ b/src/L10NSharp/XLiffUtils/XliffXmlSerializationHelper.cs
@@ -8,7 +8,7 @@ using System.Reflection;
 
 namespace L10NSharp.XLiffUtils
 {
-	internal static class XLiffXmlSerializationHelper
+	internal static class XliffXmlSerializationHelper
 	{
 		#region XLiffXmlReader class
 

--- a/src/L10NSharpTests/XLiffLocalizationManagerTests.cs
+++ b/src/L10NSharpTests/XLiffLocalizationManagerTests.cs
@@ -25,7 +25,7 @@ namespace L10NSharp.Tests
 			IEnumerable<MethodInfo> additionalGetStringMethodInfo = null,
 			params string[] namespaceBeginnings)
 		{
-			var manager = new XLiffLocalizationManager(appId, null, appName, appVersion, directoryOfInstalledLocFiles,
+			var manager = new XliffLocalizationManager(appId, null, appName, appVersion, directoryOfInstalledLocFiles,
 				directoryForGeneratedDefaultFile, directoryOfUserModifiedXliffFiles, additionalGetStringMethodInfo,
 				namespaceBeginnings);
 			Assert.That(manager.OriginalExecutableFile, Is.EqualTo(appId + ".dll"));
@@ -35,7 +35,7 @@ namespace L10NSharp.Tests
 		internal override ILocalizationManagerInternal<XLiffDocument> CreateLocalizationManager(
 			string appId, string appName, string appVersion)
 		{
-			return new XLiffLocalizationManager(appId, appName, appVersion);
+			return new XliffLocalizationManager(appId, appName, appVersion);
 		}
 
 		protected override XLiffDocument CreateNewDocument(string productVersion,    string sourceLang,
@@ -186,7 +186,7 @@ namespace L10NSharp.Tests
 			var newDoc = CreateTestDocument();
 			AdjustDocumentForTestingMerge(newDoc);
 
-			var mergedDoc = XLiffLocalizationManager.MergeXliffDocuments(newDoc, oldDoc, true);
+			var mergedDoc = XliffLocalizationManager.MergeXliffDocuments(newDoc, oldDoc, true);
 			Assert.IsNotNull(mergedDoc);
 			Assert.That(5, Is.EqualTo(oldDoc.File.Body.TransUnitsUnordered.Count()));
 			Assert.That(6, Is.EqualTo(newDoc.File.Body.TransUnitsUnordered.Count()));


### PR DESCRIPTION
fixing public capitalization would be breaking,
and writing deprecation shims for each could consume time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/111)
<!-- Reviewable:end -->
