### PR TITLE
Added FileLoadException to the list of ignorable errors in FindLocalizedStringsInType

### DIFF
--- a/src/L10NSharp/CodeReader/StringExtractor.cs
+++ b/src/L10NSharp/CodeReader/StringExtractor.cs
@@ -178,7 +178,7 @@ namespace L10NSharp.CodeReader
 						var errorMsg = $"Unable to fully load assembly {assembly.FullName}:{ex.Message} (some types may be omitted).";
 						if (OutputErrorsToConsole)
 							Console.WriteLine(errorMsg);
-						Debug.Print(errorMsg);
+						Trace.WriteLine(errorMsg);
 						typesInAssembly = ex.Types;
 					}
 					else
@@ -186,7 +186,7 @@ namespace L10NSharp.CodeReader
 						var errorMsg = $"Unable to load assembly {assembly.FullName}: {ex.Message}";
 						if (OutputErrorsToConsole)
 							Console.WriteLine(errorMsg);
-						Debug.Print(errorMsg);
+						Trace.WriteLine(errorMsg);
 						continue;
 					}
 				}
@@ -195,7 +195,7 @@ namespace L10NSharp.CodeReader
 					var errorMsg = $"Unable to load assembly {assembly.FullName}: {ex.Message}";
 					if (OutputErrorsToConsole)
 						Console.WriteLine(errorMsg);
-					Debug.Print(errorMsg);
+					Trace.WriteLine(errorMsg);
 					continue;
 				}
 
@@ -318,9 +318,10 @@ namespace L10NSharp.CodeReader
 				}
 				catch (Exception e)
 				{
-					Console.WriteLine(e.Message);
+					Trace.WriteLine(e.Message);
 					// There are several types of exception we can safely ignore:
 					if (e is FileNotFoundException || // Caused by assemblies that cannot be loaded at runtime (e.g. NUnit)
+					    e is FileLoadException || // Installed version is different from the one referenced.
 					    e is TypeLoadException || // Caused by assemblies that have odd runtime loading problems (e.g. Chorus)
 					    e is ArgumentException || // This can happen if we have a generic type (e.g. L10NSharp.dll).
 					    e is BadImageFormatException) // This can happen when loading COM interop DLLs via reflection (e.g. Interop.WIA.dll).

--- a/src/L10NSharp/XLiffUtils/XLiffLocalizationManager.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffLocalizationManager.cs
@@ -239,16 +239,16 @@ namespace L10NSharp.XLiffUtils
 			try
 			{
 				Console.WriteLine("Starting to extract localization strings for {0}", name);
-				var extractor = new L10NSharp.CodeReader.StringExtractor<XLiffDocument>();
+				var extractor = new CodeReader.StringExtractor<XLiffDocument>();
 				extractor.OutputErrorsToConsole = true;
 				var result = extractor.DoExtractingWork(additionalLocalizationMethods, namespaceBeginnings, null);
-				Console.WriteLine("Extracted {0} localization strings for {1} with {2} exceptions ignored", result.Count(), name, extractor.ExtractionExceptions.Count);
+				Trace.WriteLine($"Extracted {result.Count()} localization strings for {name} with {extractor.ExtractionExceptions.Count} exceptions ignored");
 				ExtractionExceptions.AddRange(extractor.ExtractionExceptions);
 				return result;
 			}
 			catch (Exception e)
 			{
-				Console.WriteLine("ERROR: extracting localization strings for {0} caught an exception: {1}", name, e);
+				Trace.WriteLine($"ERROR: extracting localization strings for {name} caught an exception: {e}");
 				return null;
 			}
 		}


### PR DESCRIPTION
Changed several Console.WriteLine calls to use Trace.WriteLine in hopes that we will get better information in log files when errors occur.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/112)
<!-- Reviewable:end -->
