### PR TITLE
Adding Framework 4.8 and .NET8 to targets.

### DIFF
--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -22,7 +22,7 @@ jobs:
     name: "Build and Test"
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -20,7 +20,10 @@ jobs:
 
   build-and-test:
     name: "Build and Test"
-    runs-on: windows-latest
+    strategy:
+      matrix:
+        os: [windows-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout
@@ -36,8 +39,13 @@ jobs:
     - name: Build and Pack
       run: dotnet build --configuration Release
 
+    - name: Test (Ubuntu)
+      run: dotnet test --configuration Release --no-build --filter TestCategory!=RequiresDisplay -- NUnit.TestOutputXml=TestResults
+      if: matrix.os == 'ubuntu-latest'
+
     - name: Test (Windows)
       run: dotnet test --configuration Release --no-build -- NUnit.TestOutputXml=TestResults
+      if: matrix.os != 'ubuntu-latest'
 
     - name: Upload Test Results
       if: always()
@@ -53,6 +61,7 @@ jobs:
         path: |
           output/*.nupkg
           output/*.snupkg
+      if: matrix.os == 'ubuntu-latest'
 
   publish-nuget:
     name: "Publish NuGet package"

--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -39,10 +39,6 @@ jobs:
     - name: Build and Pack
       run: dotnet build --configuration Release
 
-    - name: Test (Ubuntu)
-      run: dotnet test --configuration Release --no-build output/Release/net461/*Tests.dll --filter TestCategory!=RequiresDisplay -- NUnit.TestOutputXml=TestResults
-      if: matrix.os == 'ubuntu-latest'
-
     - name: Test (Windows)
       run: dotnet test --configuration Release --no-build -- NUnit.TestOutputXml=TestResults
       if: matrix.os != 'ubuntu-latest'

--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -40,7 +40,7 @@ jobs:
       run: dotnet build --configuration Release
 
     - name: Test (Ubuntu)
-      run: dotnet test --configuration Release --no-build output\Release\net461\*Tests.dll --filter TestCategory!=RequiresDisplay -- NUnit.TestOutputXml=TestResults
+      run: dotnet test --configuration Release --no-build output/Release/net461/*Tests.dll --filter TestCategory!=RequiresDisplay -- NUnit.TestOutputXml=TestResults
       if: matrix.os == 'ubuntu-latest'
 
     - name: Test (Windows)

--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -44,7 +44,6 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
 
     - name: Test (Windows)
-      # specify path to test assembly as workaround for https://github.com/nunit/nunit3-vs-adapter/issues/1040
       run: dotnet test --configuration Release --no-build -- NUnit.TestOutputXml=TestResults
       if: matrix.os != 'ubuntu-latest'
 

--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -40,7 +40,7 @@ jobs:
       run: dotnet build --configuration Release
 
     - name: Test (Ubuntu)
-      run: dotnet test --configuration Release --no-build --filter TestCategory!=RequiresDisplay -- NUnit.TestOutputXml=TestResults
+      run: dotnet test --configuration Release --no-build output\Release\net461\*Tests.dll --filter TestCategory!=RequiresDisplay -- NUnit.TestOutputXml=TestResults
       if: matrix.os == 'ubuntu-latest'
 
     - name: Test (Windows)

--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install .NET Core
       uses: actions/setup-dotnet@c0d4ad69d8bd405d234f1c9166d383b7a4f69ed8 # v2.1.0
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
 
     - name: Build and Pack
       run: dotnet build --configuration Release

--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -22,7 +22,7 @@ jobs:
     name: "Build and Test"
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -39,7 +39,11 @@ jobs:
     - name: Build and Pack
       run: dotnet build --configuration Release
 
-    - name: Test (Windows)
+    - name: Test (Framework 4.6.1)
+      run: dotnet test --configuration Release --no-build output\Release\net461\*Tests.dll -- NUnit.TestOutputXml=TestResults
+      if: matrix.os != 'ubuntu-latest'
+
+    - name: Test (Framework and .NET latest)
       run: dotnet test --configuration Release --no-build -- NUnit.TestOutputXml=TestResults
       if: matrix.os != 'ubuntu-latest'
 

--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Test (Windows)
       # specify path to test assembly as workaround for https://github.com/nunit/nunit3-vs-adapter/issues/1040
-      run: dotnet test --configuration Release --no-build output\Release\net461\*Tests.dll -- NUnit.TestOutputXml=TestResults
+      run: dotnet test --configuration Release --no-build -- NUnit.TestOutputXml=TestResults
       if: matrix.os != 'ubuntu-latest'
 
     - name: Upload Test Results

--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -20,10 +20,7 @@ jobs:
 
   build-and-test:
     name: "Build and Test"
-    strategy:
-      matrix:
-        os: [windows-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-latest
 
     steps:
     - name: Checkout
@@ -39,13 +36,8 @@ jobs:
     - name: Build and Pack
       run: dotnet build --configuration Release
 
-    - name: Test (Ubuntu)
-      run: dotnet test --configuration Release --no-build --filter TestCategory!=RequiresDisplay -- NUnit.TestOutputXml=TestResults
-      if: matrix.os == 'ubuntu-latest'
-
     - name: Test (Windows)
       run: dotnet test --configuration Release --no-build -- NUnit.TestOutputXml=TestResults
-      if: matrix.os != 'ubuntu-latest'
 
     - name: Upload Test Results
       if: always()
@@ -61,7 +53,6 @@ jobs:
         path: |
           output/*.nupkg
           output/*.snupkg
-      if: matrix.os == 'ubuntu-latest'
 
   publish-nuget:
     name: "Publish NuGet package"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks>net461;net481;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net461;net48;net8.0-windows</TargetFrameworks>
     <Company>SIL</Company>
     <Authors>SIL International</Authors>
     <Product>L10NSharp</Product>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,6 +25,7 @@ See full changelog at https://github.com/sillsdev/l10nsharp/blob/master/CHANGELO
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
     <UseWindowsForms>true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
   <ItemGroup>
     <!-- Without this line some projects fail to build on TC with "error : SourceRoot items

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFrameworks>net461;net481;net8.0-windows</TargetFrameworks>
     <Company>SIL</Company>
     <Authors>SIL International</Authors>
     <Product>L10NSharp</Product>
@@ -24,6 +24,7 @@ See full changelog at https://github.com/sillsdev/l10nsharp/blob/master/CHANGELO
     </AppendToReleaseNotesProperty>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
+    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
   <ItemGroup>
     <!-- Without this line some projects fail to build on TC with "error : SourceRoot items

--- a/src/CheckOrFixXliff/CheckOrFixXliff.csproj
+++ b/src/CheckOrFixXliff/CheckOrFixXliff.csproj
@@ -9,9 +9,9 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/sillsdev/l10nsharp/tree/master/src/CheckOrFixXliff</PackageProjectUrl>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
-    <NoWarn>$(NoWarn);NU5128</NoWarn>
+    <NoWarn>$(NoWarn);NU5128;NU5118</NoWarn>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net481' ">
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>

--- a/src/CheckOrFixXliff/CheckOrFixXliff.csproj
+++ b/src/CheckOrFixXliff/CheckOrFixXliff.csproj
@@ -11,7 +11,7 @@
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
     <NoWarn>$(NoWarn);NU5128;NU5118</NoWarn>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net481' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net48' ">
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>

--- a/src/CheckOrFixXliff/Program.cs
+++ b/src/CheckOrFixXliff/Program.cs
@@ -176,7 +176,7 @@ namespace CheckOrFixXliff
 		private static bool ValidateXliffAgainstSchema(string filename)
 		{
 			bool valid = true;
-			var installedXliffDir = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
+			var installedXliffDir = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().Location).LocalPath);
 			var schemaLocation = Path.Combine(installedXliffDir, "xliff-core-1.2-transitional.xsd");
 			var schemas = new XmlSchemaSet();
 			using (var reader = XmlReader.Create(schemaLocation))

--- a/src/ExtractXliff/ExtractXliff.csproj
+++ b/src/ExtractXliff/ExtractXliff.csproj
@@ -11,7 +11,7 @@
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
     <NoWarn>$(NoWarn);NU5128;NU5118</NoWarn>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net481' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == '' ">
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>

--- a/src/ExtractXliff/ExtractXliff.csproj
+++ b/src/ExtractXliff/ExtractXliff.csproj
@@ -9,9 +9,9 @@
     <PackageId>L10NSharp.ExtractXliff</PackageId>
     <PackageProjectUrl>https://github.com/sillsdev/l10nsharp/tree/master/src/ExtractXliff</PackageProjectUrl>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
-    <NoWarn>$(NoWarn);NU5128</NoWarn>
+    <NoWarn>$(NoWarn);NU5128;NU5118</NoWarn>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net481' ">
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>

--- a/src/L10NSharp/L10NCultureInfo.cs
+++ b/src/L10NSharp/L10NCultureInfo.cs
@@ -34,7 +34,13 @@ namespace L10NSharp
 			{
 				RawCultureInfo = null;
 			}
-			if (RawCultureInfo == null || RawCultureInfo.EnglishName.StartsWith("Unknown Language"))
+
+			// Starting with Windows 10, unknown cultures no longer return a RawCultureInfo containing an "Unknown Language" indication.
+			// The proper way to detect fully unknown cultures, for Windows 10 and prior, is to:
+			//    1. Check for the custom culture flag
+			//    2. Check if the three-letter language name is set to default
+			var isFullyUnknown = RawCultureInfo.CultureTypes.HasFlag(CultureTypes.UserCustomCulture) && RawCultureInfo.ThreeLetterWindowsLanguageName == "ZZZ";
+			if (RawCultureInfo == null || isFullyUnknown)
 			{
 				Name = name;
 				IsNeutralCulture = !Name.Contains("-");

--- a/src/L10NSharp/L10NCultureInfo.cs
+++ b/src/L10NSharp/L10NCultureInfo.cs
@@ -36,7 +36,7 @@ namespace L10NSharp
 			}
 
 			// Windows 10 changed the behavior of CultureInfo, in that unknown cultures no longer return a RawCultureInfo containing an "Unknown Language" indication.
-			// The proper way to detect fully unknown cultures (for Windows 10 and prior) is to:
+			// The proper way to detect fully unknown cultures (for Windows 11 and prior) is to:
 			//    1. Check for the custom culture flag
 			//    2. Check if the three-letter language name is set to default
 			// Source: https://stackoverflow.com/a/71388328/1964319

--- a/src/L10NSharp/L10NCultureInfo.cs
+++ b/src/L10NSharp/L10NCultureInfo.cs
@@ -35,10 +35,11 @@ namespace L10NSharp
 				RawCultureInfo = null;
 			}
 
-			// Starting with Windows 10, unknown cultures no longer return a RawCultureInfo containing an "Unknown Language" indication.
-			// The proper way to detect fully unknown cultures, for Windows 10 and prior, is to:
+			// Windows 10 changed the behavior of CultureInfo, in that unknown cultures no longer return a RawCultureInfo containing an "Unknown Language" indication.
+			// The proper way to detect fully unknown cultures (for Windows 10 and prior) is to:
 			//    1. Check for the custom culture flag
 			//    2. Check if the three-letter language name is set to default
+			// Source: https://stackoverflow.com/a/71388328/1964319
 			var isFullyUnknown = RawCultureInfo.CultureTypes.HasFlag(CultureTypes.UserCustomCulture) && RawCultureInfo.ThreeLetterWindowsLanguageName == "ZZZ";
 			if (RawCultureInfo == null || isFullyUnknown)
 			{

--- a/src/L10NSharp/L10NSharp.csproj
+++ b/src/L10NSharp/L10NSharp.csproj
@@ -6,7 +6,7 @@
     <PackageId>L10NSharp</PackageId>
     <PackageProjectUrl>https://github.com/sillsdev/l10nsharp</PackageProjectUrl>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net481' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net48' ">
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>

--- a/src/L10NSharp/L10NSharp.csproj
+++ b/src/L10NSharp/L10NSharp.csproj
@@ -10,18 +10,14 @@
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net481' ">
-    <PackageReference Include="GitVersion.MsBuild" Version="5.11.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
-    <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
-  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0-windows' ">
-    <PackageReference Include="GitVersion.MsBuild" Version="5.11.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
-    <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
     <PackageReference Include="System.ServiceModel.Http" Version="6.2.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="6.2.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="GitVersion.MsBuild" Version="5.11.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
+    <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/src/L10NSharp/L10NSharp.csproj
+++ b/src/L10NSharp/L10NSharp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>L10NSharp</RootNamespace>
     <Description>L10NSharp is a .NET localization library for Windows Forms applications. It collects strings which need localization when your application first runs and saves them in a XLIFF file. It can also dynamically collect strings at runtime.</Description>
@@ -6,14 +6,22 @@
     <PackageId>L10NSharp</PackageId>
     <PackageProjectUrl>https://github.com/sillsdev/l10nsharp</PackageProjectUrl>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net481' ">
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net481' ">
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
     <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0-windows' ">
+    <PackageReference Include="GitVersion.MsBuild" Version="5.11.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
+    <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
+    <PackageReference Include="System.ServiceModel.Http" Version="6.2.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="6.2.0" />
   </ItemGroup>
 </Project>

--- a/src/L10NSharpTests/L10NCultureInfoTests.cs
+++ b/src/L10NSharpTests/L10NCultureInfoTests.cs
@@ -41,7 +41,8 @@ namespace L10NSharp.Tests
 			else if (pbuci.RawCultureInfo != null)
 			{
 				Assert.AreEqual("pbu", pbuci.RawCultureInfo.Name);
-				Assert.AreEqual("Unknown Language (pbu)", pbuci.RawCultureInfo.EnglishName);
+				Assert.IsTrue(pbuci.RawCultureInfo.CultureTypes.HasFlag(CultureTypes.UserCustomCulture));
+				Assert.AreEqual("ZZZ", pbuci.RawCultureInfo.ThreeLetterWindowsLanguageName);
 			}
 		}
 

--- a/src/L10NSharpTests/L10NSharpTests.csproj
+++ b/src/L10NSharpTests/L10NSharpTests.csproj
@@ -13,7 +13,7 @@
 	  <PackageReference Include="NUnit" Version="3.13.3" />
 	  <PackageReference Include="NUnit3TestAdapter" Version="4.3.2" />
 	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net481' ">
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net48' ">
 	  <Reference Include="System.Windows.Forms" />
 	</ItemGroup>
 </Project>

--- a/src/L10NSharpTests/L10NSharpTests.csproj
+++ b/src/L10NSharpTests/L10NSharpTests.csproj
@@ -9,7 +9,7 @@
 	  <ProjectReference Include="..\L10NSharp\L10NSharp.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
 	  <PackageReference Include="NUnit" Version="3.13.3" />
 	  <PackageReference Include="NUnit3TestAdapter" Version="4.3.2" />
 	</ItemGroup>

--- a/src/L10NSharpTests/L10NSharpTests.csproj
+++ b/src/L10NSharpTests/L10NSharpTests.csproj
@@ -13,7 +13,7 @@
 	  <PackageReference Include="NUnit" Version="3.13.3" />
 	  <PackageReference Include="NUnit3TestAdapter" Version="4.3.2" />
 	</ItemGroup>
-	<ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net481' ">
 	  <Reference Include="System.Windows.Forms" />
 	</ItemGroup>
 </Project>

--- a/src/L10NSharpTests/L10NSharpTests.csproj
+++ b/src/L10NSharpTests/L10NSharpTests.csproj
@@ -9,7 +9,7 @@
 	  <ProjectReference Include="..\L10NSharp\L10NSharp.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
 	  <PackageReference Include="NUnit" Version="3.13.3" />
 	  <PackageReference Include="NUnit3TestAdapter" Version="4.3.2" />
 	</ItemGroup>

--- a/src/L10NSharpTests/TempFile.cs
+++ b/src/L10NSharpTests/TempFile.cs
@@ -249,7 +249,7 @@ namespace L10NSharp.Tests
 		public TempFolder(string testName)
 		{
 			testName = System.IO.Path.GetInvalidPathChars().Aggregate(testName,
-				(current, c) => current.Replace(c, '_')).Replace('`', '_');
+				(current, c) => current.Replace(c, '_')).Replace('`', '_').Replace('"', '_');
 			_path = System.IO.Path.Combine(BasePath, testName);
 			if(Directory.Exists(_path))
 			{

--- a/src/L10NSharpTests/XLiffSchemaValidationTests.cs
+++ b/src/L10NSharpTests/XLiffSchemaValidationTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017 SIL International
+// Copyright (c) 2017 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -42,6 +42,7 @@ namespace L10NSharp.Tests
 				Directory.CreateDirectory(folder.Path);
 				new XLiffLocalizationManagerTests().SetupManager(folder);
 
+				AppContext.SetSwitch("Switch.System.Xml.AllowDefaultResolver", true);
 				var schemas = new XmlSchemaSet();
 				using (var reader = XmlReader.Create(SchemaLocation))
 				{
@@ -88,6 +89,7 @@ namespace L10NSharp.Tests
 				Directory.CreateDirectory(folder.Path);
 				new XLiffLocalizationManagerTests().SetupManager(folder);
 
+				AppContext.SetSwitch("Switch.System.Xml.AllowDefaultResolver", true);
 				var schemas = new XmlSchemaSet();
 				using (var reader = XmlReader.Create(SchemaLocation))
 				{

--- a/src/SampleApp/SampleApp.csproj
+++ b/src/SampleApp/SampleApp.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>SampleApp</AssemblyTitle>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net481' ">
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SampleApp/SampleApp.csproj
+++ b/src/SampleApp/SampleApp.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>SampleApp</AssemblyTitle>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net481' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net48' ">
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This required platform-specific references in the project files. I also fixed a warning about Assembly.CodeBase and some .NET8 warnings about manually copying duplicate files into our nuget package folder when packing. These files appear to be duplicates of what is copied during the .NET8 packaging.

The only other change worth noting involves the "unknown language" detection in L10nCultureInfo. It appears, per [the link listed in the comment](https://stackoverflow.com/a/71388328/1964319) at that point in the code, that our method of determining an unknown language no longer works, starting with Win10 (combined with .NET). The change I made should be compatible with older OS's, like Win7, but I don't have an easy way to confirm this.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/118)
<!-- Reviewable:end -->
