### PR TITLE
Fix double enumeration of preferredLanguageIds in GetString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [L10NSharp.Windows.Forms] Restored project-local Resources support for `FallbackLanguagesDlgBase` button images (`Move`, `Move_up`, and `Move_down`).
 - [L10NSharp.Windows.Forms] Corrected resource manager base name to `L10NSharp.Windows.Forms.Properties.Resources`.
 - [L10NSharp.Windows.Forms.Tests] Corrected resource manager base name to `L10NSharp.Windows.Forms.Tests.Properties.Resources`.
+- [L10NSharp] Fixed `LocalizationManager.GetString` silently falling back to English when called with a one-shot `IEnumerable<string>` for `preferredLanguageIds`; the sequence is now materialized before use. (#139)
 
 ### Removed
 

--- a/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
+++ b/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
@@ -364,14 +364,23 @@ namespace L10NSharp.Tests
 			{
 				SetupManager(folder);
 
-				IEnumerable<string> OneShotLangIds()
+				// A C# yield-return local function produces a re-enumerable IEnumerable — each
+				// GetEnumerator() call creates a fresh state machine, so Count() would not exhaust
+				// subsequent iterations. To simulate a truly one-shot sequence we wrap a single
+				// IEnumerator in a generator: both enumerations share the same underlying enumerator,
+				// so Count() advancing it leaves nothing for GetStringFromAnyLocalizationManager.
+				IEnumerable<string> WrapSingleUse(IEnumerator<string> e)
 				{
-					yield return "fr";
-					yield return "en";
+					while (e.MoveNext())
+						yield return e.Current;
 				}
 
-				// SUT — a one-shot iterator must not be exhausted before GetStringFromAnyLocalizationManager iterates it
-				var result = LocalizationManager.GetString("blahId", "blahInEnglishCode", "comment", OneShotLangIds(), out var languageFound);
+				var oneShotLangIds = WrapSingleUse(
+					new List<string> { "fr", "en" }.GetEnumerator());
+
+				// SUT — before the fix, Count() exhausted the shared enumerator and
+				// GetStringFromAnyLocalizationManager got an empty sequence, falling back to English.
+				var result = LocalizationManager.GetString("blahId", "blahInEnglishCode", "comment", oneShotLangIds, out var languageFound);
 
 				Assert.AreEqual("blahInFrench", result);
 				Assert.AreEqual("fr", languageFound);

--- a/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
+++ b/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
@@ -358,6 +358,27 @@ namespace L10NSharp.Tests
 		}
 
 		[Test]
+		public void GetString_WithOneShotEnumerable_UsespreferredLanguages()
+		{
+			using (var folder = new TempFolder())
+			{
+				SetupManager(folder);
+
+				IEnumerable<string> OneShotLangIds()
+				{
+					yield return "fr";
+					yield return "en";
+				}
+
+				// SUT — a one-shot iterator must not be exhausted before GetStringFromAnyLocalizationManager iterates it
+				var result = LocalizationManager.GetString("blahId", "blahInEnglishCode", "comment", OneShotLangIds(), out var languageFound);
+
+				Assert.AreEqual("blahInFrench", result);
+				Assert.AreEqual("fr", languageFound);
+			}
+		}
+
+		[Test]
 		public void GetUiLanguages_EnglishIsThere()
 		{
 			var cultures = LocalizationManager.GetUILanguages(false);

--- a/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
+++ b/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
@@ -216,19 +216,19 @@ namespace L10NSharp.Tests
 
 				Assert.AreEqual("My Own English String",
 					ProxyLocalizationManager.MyOwnGetString("myOwn.English.String.Id", "My Own English String"));
-				
+
 				Assert.AreEqual("My Own English String (with comment)",
 					ProxyLocalizationManager.MyOwnGetString("myOwn.English.String.Id.With.Comment",
 					"My Own English String (with comment)",
 					"This is used to test the case where MyOwnGetString is passed as an extra method to use for extraction."));
-				
+
 				Assert.AreEqual("Click me",
 					ProxyLocalizationManager.MyOwnGetString("myDlg.btnClickMe.Text", "Click me",
 					"This is the text from the third version of MyOwnGetString.",
 					"Click this thingy to do stuff.", "Ctrl-T", btnClickMe));
-				
+
 				Assert.AreEqual("String to Localize", "String to Localize".Localize());
-				
+
 				Assert.AreEqual("Another String to Localize", "Another String to Localize".Localize("With.Id.And.Comment",
 					"This is used to test the case where Localize is passed as an extra method to use for extraction."));
 			}
@@ -358,17 +358,13 @@ namespace L10NSharp.Tests
 		}
 
 		[Test]
-		public void GetString_WithOneShotEnumerable_UsespreferredLanguages()
+		public void GetString_WithOneShotEnumerable_UsesPreferredLanguages()
 		{
 			using (var folder = new TempFolder())
 			{
 				SetupManager(folder);
 
-				// A C# yield-return local function produces a re-enumerable IEnumerable — each
-				// GetEnumerator() call creates a fresh state machine, so Count() would not exhaust
-				// subsequent iterations. To simulate a truly one-shot sequence we wrap a single
-				// IEnumerator in a generator: both enumerations share the same underlying enumerator,
-				// so Count() advancing it leaves nothing for GetStringFromAnyLocalizationManager.
+				// Wrap a single IEnumerator so the sequence can only be consumed once.
 				IEnumerable<string> WrapSingleUse(IEnumerator<string> e)
 				{
 					while (e.MoveNext())
@@ -378,9 +374,9 @@ namespace L10NSharp.Tests
 				var oneShotLangIds = WrapSingleUse(
 					new List<string> { "fr", "en" }.GetEnumerator());
 
-				// SUT — before the fix, Count() exhausted the shared enumerator and
-				// GetStringFromAnyLocalizationManager got an empty sequence, falling back to English.
-				var result = LocalizationManager.GetString("blahId", "blahInEnglishCode", "comment", oneShotLangIds, out var languageFound);
+				// SUT
+				var result = LocalizationManager.GetString("blahId", "blahInEnglishCode",
+					"comment", oneShotLangIds, out var languageFound);
 
 				Assert.AreEqual("blahInFrench", result);
 				Assert.AreEqual("fr", languageFound);

--- a/src/L10NSharp/LocalizationManagerInternal.cs
+++ b/src/L10NSharp/LocalizationManagerInternal.cs
@@ -724,6 +724,9 @@ namespace L10NSharp
 		public static string GetString(string stringId, string englishText, string comment,
 			IEnumerable<string> preferredLanguageIds, out string languageIdUsed)
 		{
+			if (preferredLanguageIds == null)
+				throw new ArgumentNullException(nameof(preferredLanguageIds));
+
 			var langIds = preferredLanguageIds.ToList();
 			if (langIds.Count == 0)
 				throw new ArgumentException("preferredLanguageIds was empty");

--- a/src/L10NSharp/LocalizationManagerInternal.cs
+++ b/src/L10NSharp/LocalizationManagerInternal.cs
@@ -724,13 +724,14 @@ namespace L10NSharp
 		public static string GetString(string stringId, string englishText, string comment,
 			IEnumerable<string> preferredLanguageIds, out string languageIdUsed)
 		{
-			if (preferredLanguageIds.Count() == 0)
+			var langIds = preferredLanguageIds.ToList();
+			if (langIds.Count == 0)
 				throw new ArgumentException("preferredLanguageIds was empty");
 
 			if (string.IsNullOrEmpty(englishText))
 				throw new ArgumentException($"{nameof(englishText)} may not be empty (because common... that can't be what you meant to do...");
 
-			var stringFromAnyLocalizationManager = GetStringFromAnyLocalizationManager(stringId, preferredLanguageIds, out languageIdUsed);
+			var stringFromAnyLocalizationManager = GetStringFromAnyLocalizationManager(stringId, langIds, out languageIdUsed);
 
 			// Even if found in the English l10n file, we prefer to use the version that came from
 			// the code.


### PR DESCRIPTION
Closes #139 (part of #135)

`GetString` enumerated `preferredLanguageIds` twice: once with `.Count()` and again inside `GetStringFromAnyLocalizationManager`. A one-shot `IEnumerable<string>` (e.g. from `yield return`) would be exhausted after the first call, causing the method to silently fall back to English regardless of the caller's preferences. Fixed by materializing to `.ToList()` at method entry.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/141)
<!-- Reviewable:end -->

Devin review: https://app.devin.ai/review/sillsdev/l10nsharp/pull/141