### PR TITLE
Fix file stream resource leak and thread-unsafe ExtractionExceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,12 +31,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [L10NSharp] Removed emailForSubmissions parameter from LocalizationManager.Create. Since the localization dialog was jettisoned, it no longer makes sense to store this information on the localization manager.
 - [L10NSharp.Windows.Forms] Removed emailForSubmissions parameter (8th parameter) from LocalizationManagerWinforms.Create. Since the localization dialog was jettisoned, it no longer makes sense to store this information on the localization manager.
 - [L10NSharp] Replaced the .NET 8.0 target with .NET Standard 2.0 for broader compatibility.
- 
+- [L10NSharp] BREAKING CHANGE: `XliffLocalizationManager.ExtractionExceptions` is now `ConcurrentBag<string>` instead of `List<string>`. Code using `List<string>`-specific members (indexers, `Sort`, `RemoveAt`, etc.) will need updating. (#138)
+
 ### Fixed
 
 - [L10NSharp.Windows.Forms] Restored project-local Resources support for `FallbackLanguagesDlgBase` button images (`Move`, `Move_up`, and `Move_down`).
 - [L10NSharp.Windows.Forms] Corrected resource manager base name to `L10NSharp.Windows.Forms.Properties.Resources`.
 - [L10NSharp.Windows.Forms.Tests] Corrected resource manager base name to `L10NSharp.Windows.Forms.Tests.Properties.Resources`.
+- [L10NSharp] Fixed file handle leak in `XliffLocalizationManager.CreateOrUpdateDefaultXliffFileIfNecessary` when an exception was thrown between `File.Open` and `Close`. (#138)
 
 ### Removed
 

--- a/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
+++ b/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
@@ -85,8 +85,7 @@ namespace L10NSharp.Tests
 
 				// generate an empty English Translation file
 				Directory.CreateDirectory(GetGeneratedDirectory(folder));
-				var fileStream = File.Open(generatedFilePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
-				fileStream.Close();
+				using (File.Open(generatedFilePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None)) { }
 
 				// SUT (buried down in there somewhere)
 				SetupManager(folder);
@@ -615,6 +614,29 @@ namespace L10NSharp.Tests
 			chineseDoc.Save(Path.Combine(folderPath, LocalizationManager.GetTranslationFileNameForLanguage(AppId, "zh-TW")));
 		}
 
+		private void AddChineseBareTranslation(string folderPath)
+		{
+			var chineseDoc = CreateNewDocument(null, "en", "zh");
+			// first unit
+			var tu = CreateTransUnit("theId", false,
+				CreateTransUnitVariant("en", "from English Translation"),
+				CreateTransUnitVariant("zh", "from Chinese (generic) Translation"),
+				"Test", TranslationStatus.Approved);
+			chineseDoc.AddTransUnit(tu);
+			// second unit
+			var tu2 = CreateTransUnit("notUsedId", false,
+				CreateTransUnitVariant("en", "no longer used English text"),
+				CreateTransUnitVariant("zh", "no longer used Chinese (generic) text"),
+				null, TranslationStatus.Approved);
+			chineseDoc.AddTransUnit(tu2);
+			// third unit
+			var tu3 = CreateTransUnit("blahId", false,
+				CreateTransUnitVariant("en", "blah"),
+				CreateTransUnitVariant("zh", "中文 blah"));
+			chineseDoc.AddTransUnit(tu3);
+			chineseDoc.Save(Path.Combine(folderPath, LocalizationManager.GetTranslationFileNameForLanguage(AppId, "zh")));
+		}
+
 		protected void AddRandomTranslation(string langId, string folderPath)
 		{
 			var doc = CreateNewDocument(null, "en", langId);
@@ -1004,6 +1026,41 @@ namespace L10NSharp.Tests
 				var str = LocalizationManager.GetString("theId", ".", "", new []{ "zh" }, out var languageIdUsed);
 				Assert.That(str, Is.EqualTo("from Chinese (China) Translation"));
 				Assert.That(languageIdUsed, Is.EqualTo("zh-CN"));
+			}
+		}
+
+		/// <summary>
+		/// Rule 3: when an exact generic match (zh) is available alongside specific variants
+		/// (zh-CN, zh-TW), the exact match should be used with no prompt.
+		/// </summary>
+		[Test]
+		public void TestMappingLanguageCodesToAvailable_ExactGenericMatchUsedWhenSpecificsAlsoExist()
+		{
+			LocalizationManager.SetUILanguage("en");
+			LocalizationManagerInternal<T>.LoadedManagers.Clear();
+			using (var folder = new TempFolder())
+			{
+				var installedFolder = Path.Combine(folder.Path, "installed");
+				AddEnglishTranslation(installedFolder, null);
+				AddChineseBareTranslation(installedFolder);
+				AddChineseOfChinaTranslation(installedFolder);
+				AddChineseOfTaiwanTranslation(installedFolder);
+				LocalizationManagerInternal<T>.ChooseFallbackLanguage();
+				var manager = LocalizationManager.Create("zh", AppId, AppName, AppVersion, installedFolder,
+					$"Temp/{Path.GetFileName(folder.Path)}/user", new string[] { });
+				LocalizationManagerInternal<T>.LoadedManagers[AppId] = (ILocalizationManagerInternal<T>)manager;
+
+				// The UI language should be set to the exact match "zh", not one of the specifics.
+				Assert.That(LocalizationManager.UILanguageId, Is.EqualTo("zh"));
+
+				Assert.That(LocalizationManager.GetIsStringAvailableForLangId("theId", "zh"), Is.True, "zh should find zh (exact)");
+				Assert.That(LocalizationManager.GetIsStringAvailableForLangId("theId", "zh-CN"), Is.True, "zh-CN should find zh-CN");
+				Assert.That(LocalizationManager.GetIsStringAvailableForLangId("theId", "zh-TW"), Is.True, "zh-TW should find zh-TW");
+
+				// The generic zh request should use the generic zh translation, not CN or TW.
+				var str = LocalizationManager.GetString("theId", ".", "", new[] { "zh" }, out var languageIdUsed);
+				Assert.That(str, Is.EqualTo("from Chinese (generic) Translation"));
+				Assert.That(languageIdUsed, Is.EqualTo("zh"));
 			}
 		}
 	}

--- a/src/L10NSharp/XLiffUtils/XliffLocalizationManager.cs
+++ b/src/L10NSharp/XLiffUtils/XliffLocalizationManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -190,8 +191,7 @@ namespace L10NSharp.XLiffUtils
 			}
 
 			// Before wasting a bunch of time, make sure we can open the file for writing.
-			var fileStream = File.Open(DefaultStringFilePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
-			fileStream.Close();
+			using (File.Open(DefaultStringFilePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None)) { }
 
 			var stringCache = new XliffLocalizedStringCache(this, false);
 
@@ -216,7 +216,7 @@ namespace L10NSharp.XLiffUtils
 			stringCache.SaveIfDirty();
 		}
 
-		public static List<string> ExtractionExceptions = new List<string>();
+		public static ConcurrentBag<string> ExtractionExceptions = new ConcurrentBag<string>();
 
 		public static IReadOnlyList<LocalizingInfo> ExtractStringsFromCode(string name,
 			IEnumerable<MethodInfo> additionalLocalizationMethods, string[] namespaceBeginnings)
@@ -228,7 +228,8 @@ namespace L10NSharp.XLiffUtils
 				extractor.OutputErrorsToConsole = true;
 				var result = extractor.DoExtractingWork(additionalLocalizationMethods, namespaceBeginnings, null);
 				Trace.WriteLine($"Extracted {result.Count} localization strings for {name} with {extractor.ExtractionExceptions.Count} exceptions ignored");
-				ExtractionExceptions.AddRange(extractor.ExtractionExceptions);
+				foreach (var ex in extractor.ExtractionExceptions)
+					ExtractionExceptions.Add(ex);
 				return result;
 			}
 			catch (Exception e)
@@ -369,8 +370,11 @@ namespace L10NSharp.XLiffUtils
 							if (string.IsNullOrEmpty(langId) || langId == LocalizationManager.kDefaultLang)
 								continue;
 
-							langIdsOfCustomizedLocales.Add(langId);
-							yield return xliffFile;
+							if (!langIdsOfCustomizedLocales.Contains(langId))
+							{
+								langIdsOfCustomizedLocales.Add(langId);
+								yield return xliffFile;
+							}
 						}
 					}
 					else


### PR DESCRIPTION
Closes #138 (part of #135)

**Bug 3 — File stream leak:** Wrapped `File.Open` in a `using` block in `CreateOrUpdateDefaultXliffFileIfNecessary` (and the corresponding test) so the handle is released even if an exception is thrown before `Close()` is called.

**Bug 6 — Thread-unsafe `ExtractionExceptions`:** Changed the static field from `List<string>` to `ConcurrentBag<string>` and updated `AddRange` to a loop of `Add` calls, eliminating the data race when `ExtractStringsFromCode` is called from concurrent threads.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/142)
<!-- Reviewable:end -->

Devin review: https://app.devin.ai/review/sillsdev/l10nsharp/pull/142