### PR TITLE
Fix NRE in AddTransUnit and TOCTOU race in AddTransUnitRaw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [L10NSharp.Windows.Forms] Restored project-local Resources support for `FallbackLanguagesDlgBase` button images (`Move`, `Move_up`, and `Move_down`).
 - [L10NSharp.Windows.Forms] Corrected resource manager base name to `L10NSharp.Windows.Forms.Properties.Resources`.
 - [L10NSharp.Windows.Forms.Tests] Corrected resource manager base name to `L10NSharp.Windows.Forms.Tests.Properties.Resources`.
+- [L10NSharp] Fixed `NullReferenceException` in `XLiffBody.AddTransUnit` when a trans-unit has no source variant (e.g. from a malformed XLIFF file). (#137)
+- [L10NSharp] Fixed race condition in `XLiffBody.AddTransUnitRaw` where two concurrent threads with the same translation-unit ID could both bypass the duplicate check and silently overwrite each other's entry. (#137)
 
 ### Removed
 

--- a/src/L10NSharp.Tests/XLiffLocalizationManagerTests.cs
+++ b/src/L10NSharp.Tests/XLiffLocalizationManagerTests.cs
@@ -239,6 +239,16 @@ namespace L10NSharp.Tests
 				}, true);
 		}
 
+		[Test]
+		public void AddTransUnit_NullSourceWithNonNullTarget_DoesNotThrow()
+		{
+			var body = new XLiffBody();
+			var tu = new XLiffTransUnit { Id = "some-id" };
+			tu.Source = null;
+			tu.Target = new XLiffTransUnitVariant { Lang = "fr" };
+			Assert.DoesNotThrow(() => body.AddTransUnit(tu));
+		}
+
 		private void CheckMergedTransUnit(XLiffTransUnit tu, string sourceText, string[] notes, bool isDynamic)
 		{
 			Assert.IsNotNull(tu);

--- a/src/L10NSharp.Tests/XLiffLocalizationManagerTests.cs
+++ b/src/L10NSharp.Tests/XLiffLocalizationManagerTests.cs
@@ -240,12 +240,12 @@ namespace L10NSharp.Tests
 		}
 
 		[Test]
-		public void AddTransUnit_NullSourceWithNonNullTarget_DoesNotThrow()
+		public void AddTransUnit_NullSourceNullTarget_DoesNotThrow()
 		{
 			var body = new XLiffBody();
-			var tu = new XLiffTransUnit { Id = "some-id" };
-			tu.Source = null;
-			tu.Target = new XLiffTransUnitVariant { Lang = "fr" };
+			// Target is null (default), so the else branch in AddTransUnit fires.
+			// Before the fix: tu.Source.Value throws NRE when Source is also null.
+			var tu = new XLiffTransUnit { Id = "some-id", Source = null };
 			Assert.DoesNotThrow(() => body.AddTransUnit(tu));
 		}
 

--- a/src/L10NSharp/XLiffUtils/XLiffBody.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffBody.cs
@@ -155,17 +155,17 @@ namespace L10NSharp.XLiffUtils
 					tu.Id = (System.Threading.Interlocked.Increment(ref _transUnitId)).ToString();
 					key = tu.Id;
 				}
+
+				// If a translation unit with the specified id already exists, then quit here.
+				if (GetTransUnitForId(tu.Id) != null)
+					return false;
+				_transUnitDict[key] = tu;
+				return true;
 			}
 			finally
 			{
 				if (lockTaken) _transUnitIdLock.Exit(false);
 			}
-
-			// If a translation unit with the specified id already exists, then quit here.
-			if (GetTransUnitForId(tu.Id) != null)
-				return false;
-			_transUnitDict[key] = tu;
-			return true;
 		}
 		public bool AddTransUnit(XLiffTransUnit tu)
 		{
@@ -176,7 +176,7 @@ namespace L10NSharp.XLiffUtils
 			// the source value there.
 			if (tu.Target != null && tu.Target.Value != null)
 				TranslationsById[tu.Id] = tu.Target.Value;
-			else
+			else if (tu.Source != null)
 				TranslationsById[tu.Id] = tu.Source.Value;
 			return true;
 		}
@@ -246,7 +246,7 @@ namespace L10NSharp.XLiffUtils
 							{
 								++_translatedCount;
 							}
-							else if (tu.Target.Value != tu.Source.Value &&
+							else if (tu.Source != null && tu.Target.Value != tu.Source.Value &&
 							         tu.Target.TargetState == XLiffTransUnitVariant.TranslationState.Undefined)
 							{
 								++_translatedCount;


### PR DESCRIPTION
Closes #137 (part of #135)

**Bug 1 — NRE in `AddTransUnit`:** Added `null` guard on `tu.Source` before accessing `.Value` in `AddTransUnit` and in the `NumberTranslated` property.

**Bug 4 — TOCTOU in `AddTransUnitRaw`:** Moved the duplicate-check (`GetTransUnitForId`) and dictionary write inside the `SpinLock` scope so two threads with the same ID cannot both pass the check and both write.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/143)
<!-- Reviewable:end -->

Devin review: https://app.devin.ai/review/sillsdev/l10nsharp/pull/143