### PR TITLE
Strip duplicate and stale Not-found notes in ExtractXliff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [L10NSharp.Windows.Forms] Restored project-local Resources support for `FallbackLanguagesDlgBase` button images (`Move`, `Move_up`, and `Move_down`).
 - [L10NSharp.Windows.Forms] Corrected resource manager base name to `L10NSharp.Windows.Forms.Properties.Resources`.
 - [L10NSharp.Windows.Forms.Tests] Corrected resource manager base name to `L10NSharp.Windows.Forms.Tests.Properties.Resources`.
+- [L10NSharp] Fixed `ExtractXliff` accumulating duplicate "Not found in static scan" notes on successive runs; the note is now replaced rather than appended, and removed when the string is subsequently found. (#113)
 
 ### Removed
 

--- a/src/L10NSharp.Tests/XLiffLocalizationManagerTests.cs
+++ b/src/L10NSharp.Tests/XLiffLocalizationManagerTests.cs
@@ -272,7 +272,7 @@ namespace L10NSharp.Tests
 
 			var tu = mergedDoc2.GetTransUnitForId("That.test");
 			Assert.IsNotNull(tu);
-			Assert.That(tu.Notes.Any(n => n.Text.StartsWith("Not found")), Is.False);
+			Assert.That(tu.Notes.Any(n => n.Text.Contains("Not found")), Is.False);
 		}
 
 		private void CheckMergedTransUnit(XLiffTransUnit tu, string sourceText, string[] notes, bool isDynamic)

--- a/src/L10NSharp.Tests/XLiffLocalizationManagerTests.cs
+++ b/src/L10NSharp.Tests/XLiffLocalizationManagerTests.cs
@@ -239,6 +239,42 @@ namespace L10NSharp.Tests
 				}, true);
 		}
 
+		[Test]
+		public void MergeXliffDocuments_RunTwice_DoesNotDuplicateNotFoundNotes()
+		{
+			var oldDoc = CreateTestDocument();
+			var newDoc = CreateTestDocument();
+			AdjustDocumentForTestingMerge(newDoc);
+
+			var mergedDoc = XliffLocalizationManager.MergeXliffDocuments(newDoc, oldDoc, true);
+			var tuAfterFirstMerge = mergedDoc.GetTransUnitForId("That.test");
+			Assert.IsNotNull(tuAfterFirstMerge);
+			var expectedNoteCount = tuAfterFirstMerge.Notes.Count;
+
+			var mergedDoc2 = XliffLocalizationManager.MergeXliffDocuments(newDoc, mergedDoc, true);
+			var tuAfterSecondMerge = mergedDoc2.GetTransUnitForId("That.test");
+			Assert.IsNotNull(tuAfterSecondMerge);
+			Assert.That(expectedNoteCount, Is.EqualTo(tuAfterSecondMerge.Notes.Count));
+		}
+
+		[Test]
+		public void MergeXliffDocuments_StringFoundAfterBeingMissing_RemovesNotFoundNote()
+		{
+			var oldDoc = CreateTestDocument();
+			var newDoc = CreateTestDocument();
+			AdjustDocumentForTestingMerge(newDoc);
+
+			var mergedDoc = XliffLocalizationManager.MergeXliffDocuments(newDoc, oldDoc, true);
+
+			// newDoc2 is NOT adjusted, so "That.test" IS present in it
+			var newDoc2 = CreateTestDocument();
+			var mergedDoc2 = XliffLocalizationManager.MergeXliffDocuments(newDoc2, mergedDoc, true);
+
+			var tu = mergedDoc2.GetTransUnitForId("That.test");
+			Assert.IsNotNull(tu);
+			Assert.That(tu.Notes.Any(n => n.Text.StartsWith("Not found")), Is.False);
+		}
+
 		private void CheckMergedTransUnit(XLiffTransUnit tu, string sourceText, string[] notes, bool isDynamic)
 		{
 			Assert.IsNotNull(tu);

--- a/src/L10NSharp/XLiffUtils/XliffLocalizationManager.cs
+++ b/src/L10NSharp/XLiffUtils/XliffLocalizationManager.cs
@@ -539,7 +539,7 @@ namespace L10NSharp.XLiffUtils
 		{
 			UiLanguageChanged?.Invoke(this, EventArgs.Empty);
 		}
-		
+
 		/// ------------------------------------------------------------------------------------
 		public override string ToString()
 		{
@@ -608,8 +608,8 @@ namespace L10NSharp.XLiffUtils
 					{
 						foreach (var note in tuOld.Notes)
 						{
-							// Skip "Not found" notes — the string IS found in this run.
-							if (note.Text.StartsWith("Not found in static scan") || note.Text.StartsWith("Not found when running"))
+							// Skip "Not found[...]" notes — the string IS found in this run.
+							if (note.Text.StartsWith("Not found"))
 								continue;
 							bool haveAlready = false;
 							foreach (var newNote in tu.Notes)
@@ -658,9 +658,9 @@ namespace L10NSharp.XLiffUtils
 						{
 							++missingDynamicStringCount;
 							missingDynamicStringIds.Add(tu.Id);
-							if (newDynamicCount > 0)	// note only if attempt made to collect dynamic strings
+							if (newDynamicCount > 0) // note only if attempt made to collect dynamic strings
 							{
-								tu.Notes.RemoveAll(n => n.Text.StartsWith("Not found in static scan") || n.Text.StartsWith("Not found when running"));
+								tu.Notes.RemoveAll(n => n.Text.StartsWith("Not found"));
 								tu.AddNote("en", $"Not found when running compiled program (version {xliffNew.File.ProductVersion})");
 							}
 						}
@@ -668,7 +668,7 @@ namespace L10NSharp.XLiffUtils
 						{
 							++missingStringCount;
 							missingStringIds.Add(tu.Id);
-							tu.Notes.RemoveAll(n => n.Text.StartsWith("Not found in static scan") || n.Text.StartsWith("Not found when running"));
+							tu.Notes.RemoveAll(n => n.Text.StartsWith("Not found"));
 							tu.AddNote("en", $"Not found in static scan of compiled code (version {xliffNew.File.ProductVersion})");
 						}
 					}

--- a/src/L10NSharp/XLiffUtils/XliffLocalizationManager.cs
+++ b/src/L10NSharp/XLiffUtils/XliffLocalizationManager.cs
@@ -608,6 +608,9 @@ namespace L10NSharp.XLiffUtils
 					{
 						foreach (var note in tuOld.Notes)
 						{
+							// Skip "Not found" notes — the string IS found in this run.
+							if (note.Text.StartsWith("Not found in static scan") || note.Text.StartsWith("Not found when running"))
+								continue;
 							bool haveAlready = false;
 							foreach (var newNote in tu.Notes)
 							{
@@ -656,12 +659,16 @@ namespace L10NSharp.XLiffUtils
 							++missingDynamicStringCount;
 							missingDynamicStringIds.Add(tu.Id);
 							if (newDynamicCount > 0)	// note only if attempt made to collect dynamic strings
+							{
+								tu.Notes.RemoveAll(n => n.Text.StartsWith("Not found in static scan") || n.Text.StartsWith("Not found when running"));
 								tu.AddNote("en", $"Not found when running compiled program (version {xliffNew.File.ProductVersion})");
+							}
 						}
 						else
 						{
 							++missingStringCount;
 							missingStringIds.Add(tu.Id);
+							tu.Notes.RemoveAll(n => n.Text.StartsWith("Not found in static scan") || n.Text.StartsWith("Not found when running"));
 							tu.AddNote("en", $"Not found in static scan of compiled code (version {xliffNew.File.ProductVersion})");
 						}
 					}


### PR DESCRIPTION
Closes #113

Each run of `ExtractXliff.exe --base-xliff` appended a fresh "Not found in static scan..." note without removing the previous one, causing notes to accumulate indefinitely.

- Before adding a "Not found" note, any existing notes with that prefix are now stripped so at most one such note exists per string per run.
- When a string IS found in a subsequent extraction, any "Not found" notes from previous runs are no longer copied forward to the output.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/144)
<!-- Reviewable:end -->

Devin review: https://app.devin.ai/review/sillsdev/l10nsharp/pull/144