### PR TITLE
Fix FilenamesToAddToCache yielding duplicates when UseLanguageCodeFolders=true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [L10NSharp.Windows.Forms] Restored project-local Resources support for `FallbackLanguagesDlgBase` button images (`Move`, `Move_up`, and `Move_down`).
 - [L10NSharp.Windows.Forms] Corrected resource manager base name to `L10NSharp.Windows.Forms.Properties.Resources`.
 - [L10NSharp.Windows.Forms.Tests] Corrected resource manager base name to `L10NSharp.Windows.Forms.Tests.Properties.Resources`.
+- [L10NSharp] Fixed `FilenamesToAddToCache` yielding both the custom and installed XLIFF for the same language when `UseLanguageCodeFolders` is `true`, causing custom translations to be silently overwritten by installed ones. (#140)
 
 ### Removed
 

--- a/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
+++ b/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
@@ -448,6 +448,59 @@ namespace L10NSharp.Tests
 			}
 		}
 
+		/// <summary>
+		/// Regression test for fix/135: when UseLanguageCodeFolders is true and both an installed
+		/// and a user-modified file exist for the same language, the custom (user-modified) file
+		/// must win. Before the fix, FilenamesToAddToCache yielded both files and whichever loaded
+		/// last would overwrite the other.
+		/// </summary>
+		[Test]
+		public void CustomTranslation_TakesPrecedenceOverInstalled_WithLanguageCodeFolders()
+		{
+			try
+			{
+				LocalizationManager.UseLanguageCodeFolders = true;
+				using (var folder = new TempFolder())
+				{
+					// Set up the English default in the installed directory.
+					AddEnglishTranslation(GetInstalledDirectory(folder), "1.0");
+
+					// Set up an installed Arabic translation with value "inArabic".
+					AddArabicTranslation(GetInstalledDirectory(folder));
+
+					// Set up a user-modified Arabic translation for the same "theId" string
+					// with a different value to confirm the custom one wins.
+					var customArabicDoc = CreateNewDocument(null, "en", "ar");
+					var customTu = CreateTransUnit("theId", false,
+						CreateTransUnitVariant("en", "wrong"),
+						CreateTransUnitVariant("ar", "custom arabic translation"),
+						"Test", TranslationStatus.Approved);
+					customArabicDoc.AddTransUnit(customTu);
+					var customArabicPath = Path.Combine(GetUserModifiedDirectory(folder),
+						LocalizationManager.GetTranslationFileNameForLanguage(AppId, "ar"));
+					Directory.CreateDirectory(Path.GetDirectoryName(customArabicPath));
+					customArabicDoc.Save(customArabicPath);
+
+					// Set up the localization manager.
+					var manager = CreateLocalizationManager(AppId, AppName, AppVersion,
+						GetInstalledDirectory(folder), GetGeneratedDirectory(folder),
+						GetUserModifiedDirectory(folder));
+					LocalizationManagerInternal<T>.LoadedManagers[AppId] = manager;
+
+					LocalizationManager.SetUILanguage("ar");
+
+					// SUT: the custom translation must win over the installed one.
+					Assert.AreEqual("custom arabic translation",
+						LocalizationManager.GetString("theId", "default"),
+						"Custom (user-modified) translation should take precedence over installed translation when UseLanguageCodeFolders is true");
+				}
+			}
+			finally
+			{
+				LocalizationManager.UseLanguageCodeFolders = false;
+			}
+		}
+
 		[Test]
 		public void GetUiLanguages_AzeriHasHackedNativeName()
 		{

--- a/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
+++ b/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
@@ -13,7 +13,7 @@ using NUnit.Framework;
 
 namespace L10NSharp.Tests
 {
-	public abstract class LocalizationManagerTestsBase<T> where T: IDocument
+	public abstract class LocalizationManagerTestsBase<T> where T : IDocument
 	{
 		protected const string AppId = "test";
 		protected const string AppName = "unit test";
@@ -216,19 +216,19 @@ namespace L10NSharp.Tests
 
 				Assert.AreEqual("My Own English String",
 					ProxyLocalizationManager.MyOwnGetString("myOwn.English.String.Id", "My Own English String"));
-				
+
 				Assert.AreEqual("My Own English String (with comment)",
 					ProxyLocalizationManager.MyOwnGetString("myOwn.English.String.Id.With.Comment",
 					"My Own English String (with comment)",
 					"This is used to test the case where MyOwnGetString is passed as an extra method to use for extraction."));
-				
+
 				Assert.AreEqual("Click me",
 					ProxyLocalizationManager.MyOwnGetString("myDlg.btnClickMe.Text", "Click me",
 					"This is the text from the third version of MyOwnGetString.",
 					"Click this thingy to do stuff.", "Ctrl-T", btnClickMe));
-				
+
 				Assert.AreEqual("String to Localize", "String to Localize".Localize());
-				
+
 				Assert.AreEqual("Another String to Localize", "Another String to Localize".Localize("With.Id.And.Comment",
 					"This is used to test the case where Localize is passed as an extra method to use for extraction."));
 			}

--- a/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
+++ b/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
@@ -380,39 +380,25 @@ namespace L10NSharp.Tests
 		[Test]
 		public void GetUiLanguages_FindsAllWithFolders()
 		{
-			try
+			LocalizationManager.UseLanguageCodeFolders = true;
+			using (var folder = new TempFolder())
 			{
-				LocalizationManager.UseLanguageCodeFolders = true;
-				using (var folder = new TempFolder())
-				{
-					SetupManager(folder);
-					var cultures = new List<L10NCultureInfo>(LocalizationManager.GetUILanguages(true));
-					Assert.AreEqual(4, cultures.Count);
-					CollectionAssert.AreEquivalent(new[] { "ar", "en", "fr", "es" }, cultures.Select(c => c.IetfLanguageTag).ToArray());
-					Assert.That(cultures, Is.Ordered.By("DisplayName"));
-				}
-			}
-			finally
-			{
-				LocalizationManager.UseLanguageCodeFolders = false;
+				SetupManager(folder);
+				var cultures = new List<L10NCultureInfo>(LocalizationManager.GetUILanguages(true));
+				Assert.AreEqual(4, cultures.Count);
+				CollectionAssert.AreEquivalent(new[] { "ar", "en", "fr", "es" }, cultures.Select(c => c.IetfLanguageTag).ToArray());
+				Assert.That(cultures, Is.Ordered.By("DisplayName"));
 			}
 		}
 
 		[Test]
 		public void GetDynamicStringInEnglish_NoDefault_FindsEnglishWithFolders()
 		{
-			try
+			LocalizationManager.UseLanguageCodeFolders = true;
+			using (var folder = new TempFolder())
 			{
-				LocalizationManager.UseLanguageCodeFolders = true;
-				using (var folder = new TempFolder())
-				{
-					SetupManager(folder);
-					Assert.That(LocalizationManager.GetDynamicString(AppId, "blahId", null), Is.EqualTo("blah"), "With no default supplied, should find saved English");
-				}
-			}
-			finally
-			{
-				LocalizationManager.UseLanguageCodeFolders = false;
+				SetupManager(folder);
+				Assert.That(LocalizationManager.GetDynamicString(AppId, "blahId", null), Is.EqualTo("blah"), "With no default supplied, should find saved English");
 			}
 		}
 
@@ -455,47 +441,40 @@ namespace L10NSharp.Tests
 		[Test]
 		public void CustomTranslation_TakesPrecedenceOverInstalled_WithLanguageCodeFolders()
 		{
-			try
+			LocalizationManager.UseLanguageCodeFolders = true;
+			using (var folder = new TempFolder())
 			{
-				LocalizationManager.UseLanguageCodeFolders = true;
-				using (var folder = new TempFolder())
-				{
-					// Set up the English default in the installed directory.
-					AddEnglishTranslation(GetInstalledDirectory(folder), "1.0");
+				// Set up the English default in the installed directory.
+				AddEnglishTranslation(GetInstalledDirectory(folder), "1.0");
 
-					// Set up an installed Arabic translation with value "inArabic".
-					AddArabicTranslation(GetInstalledDirectory(folder));
+				// Set up an installed Arabic translation with value "inArabic".
+				AddArabicTranslation(GetInstalledDirectory(folder));
 
-					// Set up a user-modified Arabic translation for the same "theId" string
-					// with a different value to confirm the custom one wins.
-					var customArabicDoc = CreateNewDocument(null, "en", "ar");
-					var customTu = CreateTransUnit("theId", false,
-						CreateTransUnitVariant("en", "wrong"),
-						CreateTransUnitVariant("ar", "custom arabic translation"),
-						"Test", TranslationStatus.Approved);
-					customArabicDoc.AddTransUnit(customTu);
-					var customArabicPath = Path.Combine(GetUserModifiedDirectory(folder),
-						LocalizationManager.GetTranslationFileNameForLanguage(AppId, "ar"));
-					Directory.CreateDirectory(Path.GetDirectoryName(customArabicPath));
-					customArabicDoc.Save(customArabicPath);
+				// Set up a user-modified Arabic translation for the same "theId" string
+				// with a different value to confirm the custom one wins.
+				var customArabicDoc = CreateNewDocument(null, "en", "ar");
+				var customTu = CreateTransUnit("theId", false,
+					CreateTransUnitVariant("en", "wrong"),
+					CreateTransUnitVariant("ar", "custom arabic translation"),
+					"Test", TranslationStatus.Approved);
+				customArabicDoc.AddTransUnit(customTu);
+				var customArabicPath = Path.Combine(GetUserModifiedDirectory(folder),
+					LocalizationManager.GetTranslationFileNameForLanguage(AppId, "ar"));
+				Directory.CreateDirectory(Path.GetDirectoryName(customArabicPath));
+				customArabicDoc.Save(customArabicPath);
 
-					// Set up the localization manager.
-					var manager = CreateLocalizationManager(AppId, AppName, AppVersion,
-						GetInstalledDirectory(folder), GetGeneratedDirectory(folder),
-						GetUserModifiedDirectory(folder));
-					LocalizationManagerInternal<T>.LoadedManagers[AppId] = manager;
+				// Set up the localization manager.
+				var manager = CreateLocalizationManager(AppId, AppName, AppVersion,
+					GetInstalledDirectory(folder), GetGeneratedDirectory(folder),
+					GetUserModifiedDirectory(folder));
+				LocalizationManagerInternal<T>.LoadedManagers[AppId] = manager;
 
-					LocalizationManager.SetUILanguage("ar");
+				LocalizationManager.SetUILanguage("ar");
 
-					// SUT: the custom translation must win over the installed one.
-					Assert.AreEqual("custom arabic translation",
-						LocalizationManager.GetString("theId", "default"),
-						"Custom (user-modified) translation should take precedence over installed translation when UseLanguageCodeFolders is true");
-				}
-			}
-			finally
-			{
-				LocalizationManager.UseLanguageCodeFolders = false;
+				// SUT: the custom translation must win over the installed one.
+				Assert.AreEqual("custom arabic translation",
+					LocalizationManager.GetString("theId", "default"),
+					"Custom (user-modified) translation should take precedence over installed translation when UseLanguageCodeFolders is true");
 			}
 		}
 

--- a/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
+++ b/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
@@ -449,10 +449,8 @@ namespace L10NSharp.Tests
 		}
 
 		/// <summary>
-		/// Regression test for fix/135: when UseLanguageCodeFolders is true and both an installed
-		/// and a user-modified file exist for the same language, the custom (user-modified) file
-		/// must win. Before the fix, FilenamesToAddToCache yielded both files and whichever loaded
-		/// last would overwrite the other.
+		/// When UseLanguageCodeFolders is true and both an installed and a user-modified file
+		/// exist for the same language, the custom (user-modified) file must win.
 		/// </summary>
 		[Test]
 		public void CustomTranslation_TakesPrecedenceOverInstalled_WithLanguageCodeFolders()

--- a/src/L10NSharp/XLiffUtils/XliffLocalizationManager.cs
+++ b/src/L10NSharp/XLiffUtils/XliffLocalizationManager.cs
@@ -369,8 +369,11 @@ namespace L10NSharp.XLiffUtils
 							if (string.IsNullOrEmpty(langId) || langId == LocalizationManager.kDefaultLang)
 								continue;
 
-							langIdsOfCustomizedLocales.Add(langId);
-							yield return xliffFile;
+							if (!langIdsOfCustomizedLocales.Contains(langId))
+							{
+								langIdsOfCustomizedLocales.Add(langId);
+								yield return xliffFile;
+							}
 						}
 					}
 					else


### PR DESCRIPTION
Closes #140 (part of #135)

When `UseLanguageCodeFolders` is `true`, the loop over the installed XLIFF folder was missing the `!langIdsOfCustomizedLocales.Contains(langId)` guard that the non-`UseLanguageCodeFolders` branch already applies correctly. The result was that both the custom and installed XLIFF files for the same language were yielded, causing whichever loaded last to silently overwrite the other in the string cache.

Also, when adding a regression test to `src/L10NSharp.Tests/LocalizationManagerTestsBase.cs`, I removed the try-finally block from 2 existing tests, since they are redundant with the teardown.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/145)
<!-- Reviewable:end -->

Devin review: https://app.devin.ai/review/sillsdev/l10nsharp/pull/145