### PR TITLE
Validate l10n ID is non-empty to prevent crash on empty string ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [L10NSharp] Removed emailForSubmissions parameter from LocalizationManager.Create. Since the localization dialog was jettisoned, it no longer makes sense to store this information on the localization manager.
 - [L10NSharp.Windows.Forms] Removed emailForSubmissions parameter (8th parameter) from LocalizationManagerWinforms.Create. Since the localization dialog was jettisoned, it no longer makes sense to store this information on the localization manager.
 - [L10NSharp] Replaced the .NET 8.0 target with .NET Standard 2.0 for broader compatibility.
+- [L10NSharp] `GetDynamicString`, `GetDynamicStringOrEnglish`, and `GetString` now return the English fallback text immediately when called with a null, empty, or whitespace string ID, rather than attempting a cache lookup or write.
  
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [L10NSharp] Removed emailForSubmissions parameter from LocalizationManager.Create. Since the localization dialog was jettisoned, it no longer makes sense to store this information on the localization manager.
 - [L10NSharp.Windows.Forms] Removed emailForSubmissions parameter (8th parameter) from LocalizationManagerWinforms.Create. Since the localization dialog was jettisoned, it no longer makes sense to store this information on the localization manager.
 - [L10NSharp] Replaced the .NET 8.0 target with .NET Standard 2.0 for broader compatibility.
+- [L10NSharp] BREAKING CHANGE: `LocalizationManager.GetString`, `GetDynamicString`, and `GetDynamicStringOrEnglish` now throw `ArgumentException` when called with a null or empty string ID. Previously, empty IDs were silently accepted and could produce a malformed XLIFF file that crashed on next launch.
  
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [L10NSharp] Removed emailForSubmissions parameter from LocalizationManager.Create. Since the localization dialog was jettisoned, it no longer makes sense to store this information on the localization manager.
 - [L10NSharp.Windows.Forms] Removed emailForSubmissions parameter (8th parameter) from LocalizationManagerWinforms.Create. Since the localization dialog was jettisoned, it no longer makes sense to store this information on the localization manager.
 - [L10NSharp] Replaced the .NET 8.0 target with .NET Standard 2.0 for broader compatibility.
-- [L10NSharp] BREAKING CHANGE: `LocalizationManager.GetString`, `GetDynamicString`, and `GetDynamicStringOrEnglish` now throw `ArgumentException` when called with a null or empty string ID. Previously, empty IDs were silently accepted and could produce a malformed XLIFF file that crashed on next launch.
  
 ### Fixed
 
@@ -45,6 +44,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [L10NSharp] Fixed `FilenamesToAddToCache` yielding both the custom and installed XLIFF for the same language when `UseLanguageCodeFolders` is `true`, causing custom translations to be silently overwritten by installed ones. (#140)
 - [L10NSharp] Fixed `ExtractXliff` accumulating duplicate "Not found in static scan" notes on successive runs; the note is now replaced rather than appended, and removed when the string is subsequently found. (#113)
 - [L10NSharp] Fixed `LocalizationManager.GetString` silently falling back to English when called with a one-shot `IEnumerable<string>` for `preferredLanguageIds`; the sequence is now materialized before use. (#139)
+- [L10NSharp] Fixed malformed XLIFF file produced when `GetDynamicString`/`GetString` was called with a null, empty, or whitespace string ID; the entry is now silently skipped rather than written with a blank `id` attribute that caused a crash on next launch. (#104)
 
 ### Removed
 

--- a/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
+++ b/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
@@ -344,7 +344,7 @@ namespace L10NSharp.Tests
 
 				// The guard in XliffTransUnitUpdater.Update should have prevented an empty-id
 				// entry from being added (which previously produced a malformed XLIFF file).
-				Assert.That(cache.GetString("fr", id ?? ""), Is.Null);
+				Assert.That(cache.GetString("fr", id), Is.Null);
 			}
 		}
 

--- a/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
+++ b/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
@@ -289,18 +289,64 @@ namespace L10NSharp.Tests
 			}
 		}
 
-		[Test]
-		public void GetDynamicString_WithEmptyId_ThrowsArgumentException()
+		[TestCase(null)]
+		[TestCase("")]
+		[TestCase(" ")]
+		public void GetDynamicString_WithNullOrEmptyOrWhitespaceId_ThrowsArgumentException(string id)
 		{
 			Assert.Throws<ArgumentException>(() =>
-				LocalizationManager.GetDynamicString(AppId, "", "some text"));
+				LocalizationManager.GetDynamicString(AppId, id, "some text"));
 		}
 
-		[Test]
-		public void GetDynamicStringOrEnglish_WithEmptyId_ThrowsArgumentException()
+		[TestCase(null)]
+		[TestCase("")]
+		[TestCase(" ")]
+		public void GetDynamicStringOrEnglish_WithNullOrEmptyOrWhitespaceId_ThrowsArgumentException(string id)
 		{
 			Assert.Throws<ArgumentException>(() =>
-				LocalizationManagerInternal<T>.GetDynamicStringOrEnglish(AppId, "", "some text", null, "en"));
+				LocalizationManagerInternal<T>.GetDynamicStringOrEnglish(AppId, id, "some text", null, "en"));
+		}
+
+		[TestCase(null)]
+		[TestCase("")]
+		[TestCase(" ")]
+		public void GetString_WithNullOrEmptyOrWhitespaceId_ThrowsArgumentException(string id)
+		{
+			Assert.Throws<ArgumentException>(() =>
+				LocalizationManager.GetString(id, "some text"));
+		}
+
+		[TestCase(null)]
+		[TestCase("")]
+		[TestCase(" ")]
+		public void GetString_WithPreferredLanguageIds_WithNullOrEmptyOrWhitespaceId_ThrowsArgumentException(string id)
+		{
+			Assert.Throws<ArgumentException>(() =>
+				LocalizationManager.GetString(id, "some text", null, new[] { "en" }, out _));
+		}
+
+		[TestCase(null)]
+		[TestCase("")]
+		[TestCase(" ")]
+		public void UpdateLocalizedInfo_WithNullOrEmptyOrWhitespaceId_DoesNotAddEntry(string id)
+		{
+			using (var folder = new TempFolder())
+			{
+				SetupManager(folder);
+				var cache = LocalizationManagerInternal<T>.LoadedManagers[AppId].StringCache;
+				var locInfo = new LocalizingInfo(id)
+				{
+					LangId = "fr",
+					Text = "some text",
+					UpdateFields = UpdateFields.Text
+				};
+
+				cache.UpdateLocalizedInfo(locInfo);
+
+				// The guard in XliffTransUnitUpdater.Update should have prevented an empty-id
+				// entry from being added (which previously produced a malformed XLIFF file).
+				Assert.That(cache.GetString("fr", id ?? ""), Is.Null);
+			}
 		}
 
 		[Test]

--- a/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
+++ b/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
@@ -290,6 +290,20 @@ namespace L10NSharp.Tests
 		}
 
 		[Test]
+		public void GetDynamicString_WithEmptyId_ThrowsArgumentException()
+		{
+			Assert.Throws<ArgumentException>(() =>
+				LocalizationManager.GetDynamicString(AppId, "", "some text"));
+		}
+
+		[Test]
+		public void GetDynamicStringOrEnglish_WithEmptyId_ThrowsArgumentException()
+		{
+			Assert.Throws<ArgumentException>(() =>
+				LocalizationManagerInternal<T>.GetDynamicStringOrEnglish(AppId, "", "some text", null, "en"));
+		}
+
+		[Test]
 		public void GetDynamicStringOrEnglish_LmDisposed_GivesUsefulException()
 		{
 			using (var folder = new TempFolder())

--- a/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
+++ b/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
@@ -292,37 +292,36 @@ namespace L10NSharp.Tests
 		[TestCase(null)]
 		[TestCase("")]
 		[TestCase(" ")]
-		public void GetDynamicString_WithNullOrEmptyOrWhitespaceId_ThrowsArgumentException(string id)
+		public void GetDynamicString_WithNullOrEmptyOrWhitespaceId_ReturnsFallbackText(string id)
 		{
-			Assert.Throws<ArgumentException>(() =>
-				LocalizationManager.GetDynamicString(AppId, id, "some text"));
+			Assert.That(LocalizationManager.GetDynamicString(AppId, id, "some text"), Is.EqualTo("some text"));
 		}
 
 		[TestCase(null)]
 		[TestCase("")]
 		[TestCase(" ")]
-		public void GetDynamicStringOrEnglish_WithNullOrEmptyOrWhitespaceId_ThrowsArgumentException(string id)
+		public void GetDynamicStringOrEnglish_WithNullOrEmptyOrWhitespaceId_ReturnsFallbackText(string id)
 		{
-			Assert.Throws<ArgumentException>(() =>
-				LocalizationManagerInternal<T>.GetDynamicStringOrEnglish(AppId, id, "some text", null, "en"));
+			Assert.That(LocalizationManagerInternal<T>.GetDynamicStringOrEnglish(AppId, id, "some text", null, "en"),
+				Is.EqualTo("some text"));
 		}
 
 		[TestCase(null)]
 		[TestCase("")]
 		[TestCase(" ")]
-		public void GetString_WithNullOrEmptyOrWhitespaceId_ThrowsArgumentException(string id)
+		public void GetString_WithNullOrEmptyOrWhitespaceId_ReturnsFallbackText(string id)
 		{
-			Assert.Throws<ArgumentException>(() =>
-				LocalizationManager.GetString(id, "some text"));
+			Assert.That(LocalizationManager.GetString(id, "some text"), Is.EqualTo("some text"));
 		}
 
 		[TestCase(null)]
 		[TestCase("")]
 		[TestCase(" ")]
-		public void GetString_WithPreferredLanguageIds_WithNullOrEmptyOrWhitespaceId_ThrowsArgumentException(string id)
+		public void GetString_WithPreferredLanguageIds_WithNullOrEmptyOrWhitespaceId_ReturnsFallbackText(string id)
 		{
-			Assert.Throws<ArgumentException>(() =>
-				LocalizationManager.GetString(id, "some text", null, new[] { "en" }, out _));
+			var result = LocalizationManager.GetString(id, "some text", null, new[] { "en" }, out var langUsed);
+			Assert.That(result, Is.EqualTo("some text"));
+			Assert.That(langUsed, Is.EqualTo("en"));
 		}
 
 		[TestCase(null)]

--- a/src/L10NSharp/LocalizationManagerInternal.cs
+++ b/src/L10NSharp/LocalizationManagerInternal.cs
@@ -461,8 +461,6 @@ namespace L10NSharp
 		/// ------------------------------------------------------------------------------------
 		public static string GetDynamicString(string appId, string id, string englishText, string comment)
 		{
-			if (string.IsNullOrWhiteSpace(id))
-				throw new ArgumentException("id may not be null or empty.", nameof(id));
 			return GetDynamicStringOrEnglish(appId, id, englishText, comment, LocalizationManager.UILanguageId);
 		}
 
@@ -482,7 +480,7 @@ namespace L10NSharp
 			string comment, string langId)
 		{
 			if (string.IsNullOrWhiteSpace(id))
-				throw new ArgumentException("id may not be null or empty.", nameof(id));
+				return string.IsNullOrEmpty(englishText) ? string.Empty : englishText;
 			// This happens in unit test environments or apps that have imported a library that
 			// is localized, but the app itself isn't initializing L10N yet.
 			if (LoadedManagers.Count == 0)
@@ -711,7 +709,7 @@ namespace L10NSharp
 			string englishShortcutKey, IComponent component)
 		{
 			if (string.IsNullOrWhiteSpace(stringId))
-				throw new ArgumentException("id may not be null or empty.", nameof(stringId));
+				return LocalizationManager.StripOffLocalizationInfoFromText(englishText);
 			return GetStringFromAnyLocalizationManager(stringId) ??
 				LocalizationManager.StripOffLocalizationInfoFromText(englishText);
 		}
@@ -728,7 +726,10 @@ namespace L10NSharp
 			IEnumerable<string> preferredLanguageIds, out string languageIdUsed)
 		{
 			if (string.IsNullOrWhiteSpace(stringId))
-				throw new ArgumentException("id may not be null or empty.", nameof(stringId));
+			{
+				languageIdUsed = "en";
+				return englishText;
+			}
 
 			if (preferredLanguageIds == null)
 				throw new ArgumentNullException(nameof(preferredLanguageIds));

--- a/src/L10NSharp/LocalizationManagerInternal.cs
+++ b/src/L10NSharp/LocalizationManagerInternal.cs
@@ -710,6 +710,8 @@ namespace L10NSharp
 		public static string GetString(string stringId, string englishText, string comment, string englishToolTipText,
 			string englishShortcutKey, IComponent component)
 		{
+			if (string.IsNullOrWhiteSpace(stringId))
+				throw new ArgumentException("id may not be null or empty.", nameof(stringId));
 			return GetStringFromAnyLocalizationManager(stringId) ??
 				LocalizationManager.StripOffLocalizationInfoFromText(englishText);
 		}
@@ -725,6 +727,9 @@ namespace L10NSharp
 		public static string GetString(string stringId, string englishText, string comment,
 			IEnumerable<string> preferredLanguageIds, out string languageIdUsed)
 		{
+			if (string.IsNullOrWhiteSpace(stringId))
+				throw new ArgumentException("id may not be null or empty.", nameof(stringId));
+
 			if (preferredLanguageIds == null)
 				throw new ArgumentNullException(nameof(preferredLanguageIds));
 

--- a/src/L10NSharp/LocalizationManagerInternal.cs
+++ b/src/L10NSharp/LocalizationManagerInternal.cs
@@ -461,6 +461,8 @@ namespace L10NSharp
 		/// ------------------------------------------------------------------------------------
 		public static string GetDynamicString(string appId, string id, string englishText, string comment)
 		{
+			if (string.IsNullOrWhiteSpace(id))
+				throw new ArgumentException("id may not be null or empty.", nameof(id));
 			return GetDynamicStringOrEnglish(appId, id, englishText, comment, LocalizationManager.UILanguageId);
 		}
 
@@ -479,6 +481,8 @@ namespace L10NSharp
 		public static string GetDynamicStringOrEnglish(string appId, string id, string englishText,
 			string comment, string langId)
 		{
+			if (string.IsNullOrWhiteSpace(id))
+				throw new ArgumentException("id may not be null or empty.", nameof(id));
 			// This happens in unit test environments or apps that have imported a library that
 			// is localized, but the app itself isn't initializing L10N yet.
 			if (LoadedManagers.Count == 0)

--- a/src/L10NSharp/LocalizationManagerInternal.cs
+++ b/src/L10NSharp/LocalizationManagerInternal.cs
@@ -728,7 +728,7 @@ namespace L10NSharp
 			if (string.IsNullOrWhiteSpace(stringId))
 			{
 				languageIdUsed = "en";
-				return englishText;
+				return LocalizationManager.StripOffLocalizationInfoFromText(englishText);
 			}
 
 			if (preferredLanguageIds == null)

--- a/src/L10NSharp/XLiffUtils/XliffTransUnitUpdater.cs
+++ b/src/L10NSharp/XLiffUtils/XliffTransUnitUpdater.cs
@@ -46,6 +46,8 @@ namespace L10NSharp.XLiffUtils
 			// Can't do anything without a language id.
 			if (string.IsNullOrEmpty(locInfo.LangId))
 				return _updated;
+			if (string.IsNullOrEmpty(locInfo.Id))
+				return _updated;
 
 			var xliffSource = _stringCache.GetDocument(_defaultLang);
 			Debug.Assert(xliffSource != null);

--- a/src/L10NSharp/XLiffUtils/XliffTransUnitUpdater.cs
+++ b/src/L10NSharp/XLiffUtils/XliffTransUnitUpdater.cs
@@ -46,7 +46,7 @@ namespace L10NSharp.XLiffUtils
 			// Can't do anything without a language id.
 			if (string.IsNullOrEmpty(locInfo.LangId))
 				return _updated;
-			if (string.IsNullOrEmpty(locInfo.Id))
+			if (string.IsNullOrWhiteSpace(locInfo.Id))
 				return _updated;
 
 			var xliffSource = _stringCache.GetDocument(_defaultLang);


### PR DESCRIPTION
Closes #104

Passing a null, empty, or whitespace string as the `id` argument to `GetString`/`GetDynamicString` produced a malformed or zero-length `.xlf` file that crashed the application on the next launch.

The fix is in `XliffTransUnitUpdater.Update`: a guard (mirroring the existing `LangId` check) now exits early when `id` is null/empty/whitespace, preventing the corrupt entry from ever being written. The public API methods (`GetDynamicString`, `GetDynamicStringOrEnglish`, `GetString`) return the English fallback text when called with a blank ID rather than attempting a cache lookup or write, so this is a non-breaking fix.

**Note on `StrictInitializationMode`:** the early-return in `GetString` bypasses the `StrictInitializationMode` check inside `GetStringFromAnyLocalizationManager`. An app with `StrictInitializationMode = true` and no managers loaded will now get English fallback text instead of `InvalidOperationException` when a blank ID is passed. This seems like the right behavior — throwing about missing managers when the real problem is a blank ID would be the wrong signal — but it is an observable change in that scenario.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/146)
<!-- Reviewable:end -->

Devin review: https://app.devin.ai/review/sillsdev/l10nsharp/pull/146