### PR TITLE
Add tests for language-tag matching: exact generic beats specifics

### DIFF
--- a/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
+++ b/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
@@ -615,6 +615,29 @@ namespace L10NSharp.Tests
 			chineseDoc.Save(Path.Combine(folderPath, LocalizationManager.GetTranslationFileNameForLanguage(AppId, "zh-TW")));
 		}
 
+		private void AddChineseBareTranslation(string folderPath)
+		{
+			var chineseDoc = CreateNewDocument(null, "en", "zh");
+			// first unit
+			var tu = CreateTransUnit("theId", false,
+				CreateTransUnitVariant("en", "from English Translation"),
+				CreateTransUnitVariant("zh", "from Chinese (generic) Translation"),
+				"Test", TranslationStatus.Approved);
+			chineseDoc.AddTransUnit(tu);
+			// second unit
+			var tu2 = CreateTransUnit("notUsedId", false,
+				CreateTransUnitVariant("en", "no longer used English text"),
+				CreateTransUnitVariant("zh", "no longer used Chinese (generic) text"),
+				null, TranslationStatus.Approved);
+			chineseDoc.AddTransUnit(tu2);
+			// third unit
+			var tu3 = CreateTransUnit("blahId", false,
+				CreateTransUnitVariant("en", "blah"),
+				CreateTransUnitVariant("zh", "中文 blah"));
+			chineseDoc.AddTransUnit(tu3);
+			chineseDoc.Save(Path.Combine(folderPath, LocalizationManager.GetTranslationFileNameForLanguage(AppId, "zh")));
+		}
+
 		protected void AddRandomTranslation(string langId, string folderPath)
 		{
 			var doc = CreateNewDocument(null, "en", langId);
@@ -1004,6 +1027,41 @@ namespace L10NSharp.Tests
 				var str = LocalizationManager.GetString("theId", ".", "", new []{ "zh" }, out var languageIdUsed);
 				Assert.That(str, Is.EqualTo("from Chinese (China) Translation"));
 				Assert.That(languageIdUsed, Is.EqualTo("zh-CN"));
+			}
+		}
+
+		/// <summary>
+		/// Rule 3: when an exact generic match (zh) is available alongside specific variants
+		/// (zh-CN, zh-TW), the exact match should be used with no prompt.
+		/// </summary>
+		[Test]
+		public void TestMappingLanguageCodesToAvailable_ExactGenericMatchUsedWhenSpecificsAlsoExist()
+		{
+			LocalizationManager.SetUILanguage("en");
+			LocalizationManagerInternal<T>.LoadedManagers.Clear();
+			using (var folder = new TempFolder())
+			{
+				var installedFolder = Path.Combine(folder.Path, "installed");
+				AddEnglishTranslation(installedFolder, null);
+				AddChineseBareTranslation(installedFolder);
+				AddChineseOfChinaTranslation(installedFolder);
+				AddChineseOfTaiwanTranslation(installedFolder);
+				LocalizationManagerInternal<T>.ChooseFallbackLanguage();
+				var manager = LocalizationManager.Create("zh", AppId, AppName, AppVersion, installedFolder,
+					$"Temp/{Path.GetFileName(folder.Path)}/user", new string[] { });
+				LocalizationManagerInternal<T>.LoadedManagers[AppId] = (ILocalizationManagerInternal<T>)manager;
+
+				// The UI language should be set to the exact match "zh", not one of the specifics.
+				Assert.That(LocalizationManager.UILanguageId, Is.EqualTo("zh"));
+
+				Assert.That(LocalizationManager.GetIsStringAvailableForLangId("theId", "zh"), Is.True, "zh should find zh (exact)");
+				Assert.That(LocalizationManager.GetIsStringAvailableForLangId("theId", "zh-CN"), Is.True, "zh-CN should find zh-CN");
+				Assert.That(LocalizationManager.GetIsStringAvailableForLangId("theId", "zh-TW"), Is.True, "zh-TW should find zh-TW");
+
+				// The generic zh request should use the generic zh translation, not CN or TW.
+				var str = LocalizationManager.GetString("theId", ".", "", new[] { "zh" }, out var languageIdUsed);
+				Assert.That(str, Is.EqualTo("from Chinese (generic) Translation"));
+				Assert.That(languageIdUsed, Is.EqualTo("zh"));
 			}
 		}
 	}

--- a/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
+++ b/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
@@ -216,19 +216,19 @@ namespace L10NSharp.Tests
 
 				Assert.AreEqual("My Own English String",
 					ProxyLocalizationManager.MyOwnGetString("myOwn.English.String.Id", "My Own English String"));
-				
+
 				Assert.AreEqual("My Own English String (with comment)",
 					ProxyLocalizationManager.MyOwnGetString("myOwn.English.String.Id.With.Comment",
 					"My Own English String (with comment)",
 					"This is used to test the case where MyOwnGetString is passed as an extra method to use for extraction."));
-				
+
 				Assert.AreEqual("Click me",
 					ProxyLocalizationManager.MyOwnGetString("myDlg.btnClickMe.Text", "Click me",
 					"This is the text from the third version of MyOwnGetString.",
 					"Click this thingy to do stuff.", "Ctrl-T", btnClickMe));
-				
+
 				Assert.AreEqual("String to Localize", "String to Localize".Localize());
-				
+
 				Assert.AreEqual("Another String to Localize", "Another String to Localize".Localize("With.Id.And.Comment",
 					"This is used to test the case where Localize is passed as an extra method to use for extraction."));
 			}
@@ -1030,10 +1030,6 @@ namespace L10NSharp.Tests
 			}
 		}
 
-		/// <summary>
-		/// Rule 3: when an exact generic match (zh) is available alongside specific variants
-		/// (zh-CN, zh-TW), the exact match should be used with no prompt.
-		/// </summary>
 		[Test]
 		public void TestMappingLanguageCodesToAvailable_ExactGenericMatchUsedWhenSpecificsAlsoExist()
 		{

--- a/src/L10NSharp.Windows.Forms.Tests/XliffLocalizationManagerTests.cs
+++ b/src/L10NSharp.Windows.Forms.Tests/XliffLocalizationManagerTests.cs
@@ -217,10 +217,6 @@ namespace L10NSharp.Windows.Forms.Tests
 			}
 		}
 
-		/// <summary>
-		/// Rule 3: when an exact generic match (zh) is available alongside specific variants
-		/// (zh-CN, zh-TW), the exact match should be used with no prompt.
-		/// </summary>
 		[Test]
 		public void TestMappingLanguageCodesToAvailable_ExactGenericMatchUsedWhenSpecificsAlsoExist()
 		{

--- a/src/L10NSharp.Windows.Forms.Tests/XliffLocalizationManagerTests.cs
+++ b/src/L10NSharp.Windows.Forms.Tests/XliffLocalizationManagerTests.cs
@@ -157,6 +157,29 @@ namespace L10NSharp.Windows.Forms.Tests
 			chineseDoc.Save(Path.Combine(folderPath, LocalizationManager.GetTranslationFileNameForLanguage(AppId, "zh-TW")));
 		}
 
+		private void AddChineseBareTranslation(string folderPath)
+		{
+			var chineseDoc = CreateNewDocument(null, "en", "zh");
+			// first unit
+			var tu = CreateTransUnit("theId", false,
+				CreateTransUnitVariant("en", "from English Translation"),
+				CreateTransUnitVariant("zh", "from Chinese (generic) Translation"),
+				"Test", TranslationStatus.Approved);
+			chineseDoc.AddTransUnit(tu);
+			// second unit
+			var tu2 = CreateTransUnit("notUsedId", false,
+				CreateTransUnitVariant("en", "no longer used English text"),
+				CreateTransUnitVariant("zh", "no longer used Chinese (generic) text"),
+				null, TranslationStatus.Approved);
+			chineseDoc.AddTransUnit(tu2);
+			// third unit
+			var tu3 = CreateTransUnit("blahId", false,
+				CreateTransUnitVariant("en", "blah"),
+				CreateTransUnitVariant("zh", "中文 blah"));
+			chineseDoc.AddTransUnit(tu3);
+			chineseDoc.Save(Path.Combine(folderPath, LocalizationManager.GetTranslationFileNameForLanguage(AppId, "zh")));
+		}
+
 		[Test]
 		public void TestMappingLanguageCodesToAvailable_AmbiguousOptions_PromptsUser([Values("zh-CN", "zh-TW")] string choice)
 		{
@@ -191,6 +214,49 @@ namespace L10NSharp.Windows.Forms.Tests
 				Assert.That(LocalizationManager.GetIsStringAvailableForLangId("theId", "zh-CN"), Is.True, "zh-CN should find zh-CN");
 				Assert.That(LocalizationManager.GetIsStringAvailableForLangId("theId", "zh-TW"), Is.True, "zh-TW should find zh-TW");
 				Assert.That(LocalizationManager.GetIsStringAvailableForLangId("theId", "en"), Is.True, "en should find en");
+			}
+		}
+
+		/// <summary>
+		/// Rule 3: when an exact generic match (zh) is available alongside specific variants
+		/// (zh-CN, zh-TW), the exact match should be used with no prompt.
+		/// </summary>
+		[Test]
+		public void TestMappingLanguageCodesToAvailable_ExactGenericMatchUsedWhenSpecificsAlsoExist()
+		{
+			LocalizationManagerWinforms.SetUILanguage("en", true);
+			LocalizationManagerInternalWinforms<XLiffDocument>.LoadedManagers.Clear();
+			using (var folder = new L10NSharp.Tests.TempFolder())
+			{
+				var installedFolder = Path.Combine(folder.Path, "installed");
+				// ReSharper disable once AssignNullToNotNullAttribute
+				var userRelativeFolder = Path.Combine("Temp", Path.GetFileName(Path.GetDirectoryName(folder.Path)),
+					Path.GetFileName(folder.Path), "user");
+				AddEnglishTranslation(installedFolder, null);
+				AddChineseBareTranslation(installedFolder);
+				AddChineseOfChinaTranslation(installedFolder);
+				AddChineseOfTaiwanTranslation(installedFolder);
+				var userPromptCount = 0;
+				LocalizationManagerInternalWinforms<XLiffDocument>.ChooseFallbackLanguageWinforms = (langTag, icon) =>
+				{
+					userPromptCount++;
+					return langTag;
+				};
+				var manager = LocalizationManagerWinforms.Create("zh", AppId, AppName, AppVersion, installedFolder,
+					userRelativeFolder, null, new string[] { });
+				// Exact match available — no prompt should have been shown.
+				Assert.That(userPromptCount, Is.EqualTo(0));
+				Assert.That(LocalizationManager.UILanguageId, Is.EqualTo("zh"));
+				LocalizationManagerInternal<XLiffDocument>.LoadedManagers[AppId] = (ILocalizationManagerInternal<XLiffDocument>)manager;
+
+				Assert.That(LocalizationManager.GetIsStringAvailableForLangId("theId", "zh"), Is.True, "zh should find zh (exact)");
+				Assert.That(LocalizationManager.GetIsStringAvailableForLangId("theId", "zh-CN"), Is.True, "zh-CN should find zh-CN");
+				Assert.That(LocalizationManager.GetIsStringAvailableForLangId("theId", "zh-TW"), Is.True, "zh-TW should find zh-TW");
+
+				// The generic zh request should use the generic zh translation, not CN or TW.
+				var str = LocalizationManager.GetString("theId", ".", "", new[] { "zh" }, out var languageIdUsed);
+				Assert.That(str, Is.EqualTo("from Chinese (generic) Translation"));
+				Assert.That(languageIdUsed, Is.EqualTo("zh"));
 			}
 		}
 	}


### PR DESCRIPTION
Closes #109

PR #110 fixed the language-tag matching logic in `XliffLocalizedStringCache.LoadXliffAndUpdateExistingLanguageMap` but left one rule untested: when an exact generic tag (e.g. `zh`) is available alongside specific variants (`zh-CN`, `zh-TW`), the exact match should be used without prompting the user.

Adds `TestMappingLanguageCodesToAvailable_ExactGenericMatchUsedWhenSpecificsAlsoExist` to both:
- `src/L10NSharp.Tests/LocalizationManagerTestsBase.cs`
- `src/L10NSharp.Windows.Forms.Tests/XliffLocalizationManagerTests.cs`

Each test sets up all three variants, initialises with `"zh"`, and asserts: no prompt fires, `UILanguageId == "zh"`, and `GetString` returns the generic-`zh` translation (not CN or TW).

Devin review: https://app.devin.ai/review/sillsdev/l10nsharp/pull/147

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/147)
<!-- Reviewable:end -->
