### PR TITLE
Fix NRE in XLiffBody.AddTransUnit when tu.Source is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [L10NSharp] Fixed `FilenamesToAddToCache` yielding both the custom and installed XLIFF for the same language when `UseLanguageCodeFolders` is `true`, causing custom translations to be silently overwritten by installed ones.
 - [L10NSharp] Fixed `ExtractXliff` accumulating duplicate "Not found in static scan" notes on successive runs; the note is now replaced rather than appended, and removed when the string is subsequently found.
 - [L10NSharp] Fixed `LocalizationManager.GetString` silently falling back to English when called with a one-shot `IEnumerable<string>` for `preferredLanguageIds`; the sequence is now materialized before use.
-- [L10NSharp] Fixed `NullReferenceException` in `XLiffBody.AddTransUnit` when a trans-unit has no source variant (e.g. from a malformed XLIFF file).
+- [L10NSharp] Fixed `NullReferenceException` in `XLiffBody.AddTransUnit` and  `XliffLocalizationManager.MergeXliffDocuments` when a trans-unit has no source variant (e.g., from a malformed XLIFF file).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,13 +38,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [L10NSharp.Windows.Forms] Restored project-local Resources support for `FallbackLanguagesDlgBase` button images (`Move`, `Move_up`, and `Move_down`).
 - [L10NSharp.Windows.Forms] Corrected resource manager base name to `L10NSharp.Windows.Forms.Properties.Resources`.
 - [L10NSharp.Windows.Forms.Tests] Corrected resource manager base name to `L10NSharp.Windows.Forms.Tests.Properties.Resources`.
-- [L10NSharp] Fixed `NullReferenceException` in `XLiffBody.AddTransUnit` when a trans-unit has no source variant (e.g. from a malformed XLIFF file). (#149)
-- [L10NSharp] Fixed file handle leak in `XliffLocalizationManager.CreateOrUpdateDefaultXliffFileIfNecessary` when an exception was thrown between `File.Open` and `Close`. (#151)
-- [L10NSharp] Fixed race condition in `XLiffBody.AddTransUnitRaw` where two concurrent threads with the same translation-unit ID could both bypass the duplicate check and silently overwrite each other's entry. (#150)
-- [L10NSharp] Eliminated unnecessary cross-instance lock contention in `XLiffBody` by making `_transUnitIdLock` instance-level instead of static. (#150)
-- [L10NSharp] Fixed `FilenamesToAddToCache` yielding both the custom and installed XLIFF for the same language when `UseLanguageCodeFolders` is `true`, causing custom translations to be silently overwritten by installed ones. (#140)
-- [L10NSharp] Fixed `ExtractXliff` accumulating duplicate "Not found in static scan" notes on successive runs; the note is now replaced rather than appended, and removed when the string is subsequently found. (#113)
-- [L10NSharp] Fixed `LocalizationManager.GetString` silently falling back to English when called with a one-shot `IEnumerable<string>` for `preferredLanguageIds`; the sequence is now materialized before use. (#139)
+- [L10NSharp] Fixed file handle leak in `XliffLocalizationManager.CreateOrUpdateDefaultXliffFileIfNecessary` when an exception was thrown between `File.Open` and `Close`.
+- [L10NSharp] Fixed race condition in `XLiffBody.AddTransUnitRaw` where two concurrent threads with the same translation-unit ID could both bypass the duplicate check and silently overwrite each other's entry.
+- [L10NSharp] Eliminated unnecessary cross-instance lock contention in `XLiffBody` by making `_transUnitIdLock` instance-level instead of static.
+- [L10NSharp] Fixed `FilenamesToAddToCache` yielding both the custom and installed XLIFF for the same language when `UseLanguageCodeFolders` is `true`, causing custom translations to be silently overwritten by installed ones.
+- [L10NSharp] Fixed `ExtractXliff` accumulating duplicate "Not found in static scan" notes on successive runs; the note is now replaced rather than appended, and removed when the string is subsequently found.
+- [L10NSharp] Fixed `LocalizationManager.GetString` silently falling back to English when called with a one-shot `IEnumerable<string>` for `preferredLanguageIds`; the sequence is now materialized before use.
+- [L10NSharp] Fixed `NullReferenceException` in `XLiffBody.AddTransUnit` when a trans-unit has no source variant (e.g. from a malformed XLIFF file).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [L10NSharp] Fixed `FilenamesToAddToCache` yielding both the custom and installed XLIFF for the same language when `UseLanguageCodeFolders` is `true`, causing custom translations to be silently overwritten by installed ones.
 - [L10NSharp] Fixed `ExtractXliff` accumulating duplicate "Not found in static scan" notes on successive runs; the note is now replaced rather than appended, and removed when the string is subsequently found.
 - [L10NSharp] Fixed `LocalizationManager.GetString` silently falling back to English when called with a one-shot `IEnumerable<string>` for `preferredLanguageIds`; the sequence is now materialized before use.
-- [L10NSharp] Fixed `NullReferenceException` in `XLiffBody.AddTransUnit` and  `XliffLocalizationManager.MergeXliffDocuments` when a trans-unit has no source variant (e.g., from a malformed XLIFF file).
+- [L10NSharp] Fixed `NullReferenceException` in `XLiffBody.AddTransUnit`, `XLiffBody.NumberTranslated`, and `XliffLocalizationManager.MergeXliffDocuments` when a trans-unit has no source variant (e.g. from a malformed XLIFF file).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [L10NSharp.Windows.Forms] Restored project-local Resources support for `FallbackLanguagesDlgBase` button images (`Move`, `Move_up`, and `Move_down`).
 - [L10NSharp.Windows.Forms] Corrected resource manager base name to `L10NSharp.Windows.Forms.Properties.Resources`.
 - [L10NSharp.Windows.Forms.Tests] Corrected resource manager base name to `L10NSharp.Windows.Forms.Tests.Properties.Resources`.
+- [L10NSharp] Fixed `NullReferenceException` in `XLiffBody.AddTransUnit` when a trans-unit has no source variant (e.g. from a malformed XLIFF file). (#149)
 
 ### Removed
 

--- a/src/L10NSharp.Tests/XLiffLocalizationManagerTests.cs
+++ b/src/L10NSharp.Tests/XLiffLocalizationManagerTests.cs
@@ -280,7 +280,29 @@ namespace L10NSharp.Tests
 			Assert.DoesNotThrow(() => body.AddTransUnit(tu));
 		}
 
-		private void CheckMergedTransUnit(XLiffTransUnit tu, string sourceText, string[] notes, bool isDynamic)
+		[Test]
+		public void MergeXliffDocuments_BaselineUnitHasNullSource_DoesNotThrow()
+		{
+			var newDoc = new XLiffDocument();
+			newDoc.AddTransUnit(new XLiffTransUnit {
+				Id = "Some.id",
+				Source = new XLiffTransUnitVariant { Lang = "en", Value = "Current text." }
+			});
+
+			var oldDoc = new XLiffDocument();
+			oldDoc.AddTransUnit(new XLiffTransUnit { Id = "Some.id", Source = null });
+
+			XLiffDocument mergedDoc = null;
+			Assert.DoesNotThrow(() =>
+				mergedDoc = XliffLocalizationManager.MergeXliffDocuments(newDoc, oldDoc, true));
+
+			var tu = mergedDoc.GetTransUnitForId("Some.id");
+			Assert.IsNotNull(tu);
+			Assert.That(tu.Notes.Any(n => n.Text.StartsWith("OLD TEXT")), Is.True);
+		}
+
+		private static void CheckMergedTransUnit(
+			XLiffTransUnit tu, string sourceText, string[] notes, bool isDynamic)
 		{
 			Assert.IsNotNull(tu);
 			Assert.That("en", Is.EqualTo(tu.Source.Lang));

--- a/src/L10NSharp.Tests/XLiffLocalizationManagerTests.cs
+++ b/src/L10NSharp.Tests/XLiffLocalizationManagerTests.cs
@@ -239,6 +239,16 @@ namespace L10NSharp.Tests
 				}, true);
 		}
 
+		[Test]
+		public void AddTransUnit_NullSourceNullTarget_DoesNotThrow()
+		{
+			var body = new XLiffBody();
+			// Target is null (default), so the else branch in AddTransUnit fires.
+			// Before the fix: tu.Source.Value throws NRE when Source is also null.
+			var tu = new XLiffTransUnit { Id = "some-id", Source = null };
+			Assert.DoesNotThrow(() => body.AddTransUnit(tu));
+		}
+
 		private void CheckMergedTransUnit(XLiffTransUnit tu, string sourceText, string[] notes, bool isDynamic)
 		{
 			Assert.IsNotNull(tu);

--- a/src/L10NSharp.Tests/XLiffLocalizationManagerTests.cs
+++ b/src/L10NSharp.Tests/XLiffLocalizationManagerTests.cs
@@ -296,9 +296,10 @@ namespace L10NSharp.Tests
 			Assert.DoesNotThrow(() =>
 				mergedDoc = XliffLocalizationManager.MergeXliffDocuments(newDoc, oldDoc, true));
 
+			// A null old source has no value to report, so no "OLD TEXT" note is added.
 			var tu = mergedDoc.GetTransUnitForId("Some.id");
 			Assert.IsNotNull(tu);
-			Assert.That(tu.Notes.Any(n => n.Text.StartsWith("OLD TEXT")), Is.True);
+			Assert.That(tu.Notes.Any(n => n.Text.StartsWith("OLD TEXT")), Is.False);
 		}
 
 		private static void CheckMergedTransUnit(

--- a/src/L10NSharp.Tests/XLiffLocalizationManagerTests.cs
+++ b/src/L10NSharp.Tests/XLiffLocalizationManagerTests.cs
@@ -278,6 +278,7 @@ namespace L10NSharp.Tests
 			var body = new XLiffBody();
 			var tu = new XLiffTransUnit { Id = "some-id", Source = null, Target = null };
 			Assert.DoesNotThrow(() => body.AddTransUnit(tu));
+		}
 
 		private void CheckMergedTransUnit(XLiffTransUnit tu, string sourceText, string[] notes, bool isDynamic)
 		{

--- a/src/L10NSharp.Tests/XLiffLocalizationManagerTests.cs
+++ b/src/L10NSharp.Tests/XLiffLocalizationManagerTests.cs
@@ -243,9 +243,7 @@ namespace L10NSharp.Tests
 		public void AddTransUnit_NullSourceNullTarget_DoesNotThrow()
 		{
 			var body = new XLiffBody();
-			// Target is null (default), so the else branch in AddTransUnit fires.
-			// Before the fix: tu.Source.Value throws NRE when Source is also null.
-			var tu = new XLiffTransUnit { Id = "some-id", Source = null };
+			var tu = new XLiffTransUnit { Id = "some-id", Source = null, Target = null };
 			Assert.DoesNotThrow(() => body.AddTransUnit(tu));
 		}
 

--- a/src/L10NSharp/XLiffUtils/XLiffBody.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffBody.cs
@@ -176,7 +176,7 @@ namespace L10NSharp.XLiffUtils
 			// the source value there.
 			if (tu.Target != null && tu.Target.Value != null)
 				TranslationsById[tu.Id] = tu.Target.Value;
-			else
+			else if (tu.Source != null)
 				TranslationsById[tu.Id] = tu.Source.Value;
 			return true;
 		}
@@ -246,7 +246,7 @@ namespace L10NSharp.XLiffUtils
 							{
 								++_translatedCount;
 							}
-							else if (tu.Target.Value != tu.Source.Value &&
+							else if (tu.Source != null && tu.Target.Value != tu.Source.Value &&
 							         tu.Target.TargetState == XLiffTransUnitVariant.TranslationState.Undefined)
 							{
 								++_translatedCount;

--- a/src/L10NSharp/XLiffUtils/XLiffBody.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffBody.cs
@@ -164,12 +164,12 @@ namespace L10NSharp.XLiffUtils
 		{
 			if (!AddTransUnitRaw(tu))
 				return false;
-		
+
 			// If the target exists, store its value in the dictionary lookup.  Otherwise, store
 			// the source value there.
-			if (tu.Target != null && tu.Target.Value != null)
+			if (tu.Target?.Value != null)
 				TranslationsById[tu.Id] = tu.Target.Value;
-			else if (tu.Source != null)
+			else if (tu.Source?.Value != null)
 				TranslationsById[tu.Id] = tu.Source.Value;
 			return true;
 		}
@@ -234,14 +234,15 @@ namespace L10NSharp.XLiffUtils
 						_translatedCount = 0;
 						foreach (var tu in TransUnitsUnordered)
 						{
-							if (tu.Target == null || string.IsNullOrWhiteSpace(tu.Target.Value))
+							if (string.IsNullOrWhiteSpace(tu.Target?.Value))
 								continue;
 							if (tu.TranslationStatus == TranslationStatus.Approved ||
 							    tu.Target.TargetState == XLiffTransUnitVariant.TranslationState.Translated)
 							{
 								++_translatedCount;
 							}
-							else if (tu.Source != null && tu.Target.Value != tu.Source.Value &&
+							else if (!string.IsNullOrWhiteSpace(tu.Source?.Value) &&
+							         tu.Target.Value != tu.Source.Value &&
 							         tu.Target.TargetState == XLiffTransUnitVariant.TranslationState.Undefined)
 							{
 								++_translatedCount;
@@ -271,7 +272,7 @@ namespace L10NSharp.XLiffUtils
 						_approvedCount = 0;
 						foreach (var tu in TransUnitsUnordered)
 						{
-							if (tu.Target == null || string.IsNullOrWhiteSpace(tu.Target.Value))
+							if (string.IsNullOrWhiteSpace(tu.Target?.Value))
 								continue;
 							if (tu.TranslationStatus == TranslationStatus.Approved)
 								++_approvedCount;

--- a/src/L10NSharp/XLiffUtils/XliffLocalizationManager.cs
+++ b/src/L10NSharp/XLiffUtils/XliffLocalizationManager.cs
@@ -634,7 +634,8 @@ namespace L10NSharp.XLiffUtils
 						{
 							++changedStringCount;
 							changedStringIds.Add(tu.Id);
-							tu.AddNote("en", $"OLD TEXT (before {xliffNew.File.ProductVersion}): {tuOld.Source?.Value}");
+							if (!string.IsNullOrWhiteSpace(tuOld.Source?.Value))
+								tu.AddNote("en", $"OLD TEXT (before {xliffNew.File.ProductVersion}): {tuOld.Source.Value}");
 						}
 						if (tuOld.Dynamic && !tu.Dynamic)
 						{

--- a/src/L10NSharp/XLiffUtils/XliffLocalizationManager.cs
+++ b/src/L10NSharp/XLiffUtils/XliffLocalizationManager.cs
@@ -630,11 +630,11 @@ namespace L10NSharp.XLiffUtils
 									tu.AddNote(note.NoteLang, "[OLD NOTE] " + note.Text);
 							}
 						}
-						if (tu.Source.Value != tuOld.Source.Value)
+						if (tu.Source?.Value != tuOld.Source?.Value)
 						{
 							++changedStringCount;
 							changedStringIds.Add(tu.Id);
-							tu.AddNote("en", $"OLD TEXT (before {xliffNew.File.ProductVersion}): {tuOld.Source.Value}");
+							tu.AddNote("en", $"OLD TEXT (before {xliffNew.File.ProductVersion}): {tuOld.Source?.Value}");
 						}
 						if (tuOld.Dynamic && !tu.Dynamic)
 						{


### PR DESCRIPTION
## Summary
- Adds null guard on `tu.Source` in `AddTransUnit` so a null Source doesn't throw when Target is also null
- Adds null guard on `tu.Source` in the `NumberTranslated` property for the same case
- Guards `tu.Source`/`tuOld.Source` in `MergeXliffDocuments` against the same NRE when a baseline XLIFF unit has no source variant; a blank old source is still counted as changed but no longer emits an empty `OLD TEXT` note
- Simplifies the null checks across `AddTransUnit`, `NumberTranslated`, and `NumberApproved` to use null-conditional (`?.`) access. As part of this, the `NumberTranslated` "differs from source" heuristic now requires a non-blank source (`IsNullOrWhiteSpace`), so a unit with a blank source no longer trivially counts as translated. `AddTransUnit` keeps `!= null` since an empty/whitespace value is still a legitimate stored translation.

Closes #149

Devin review: https://app.devin.ai/review/sillsdev/l10nsharp/pull/153

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/153)
<!-- Reviewable:end -->
