### PR TITLE
Fix TOCTOU race condition in XLiffBody.AddTransUnitRaw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [L10NSharp.Windows.Forms] Corrected resource manager base name to `L10NSharp.Windows.Forms.Properties.Resources`.
 - [L10NSharp.Windows.Forms.Tests] Corrected resource manager base name to `L10NSharp.Windows.Forms.Tests.Properties.Resources`.
 - [L10NSharp] Fixed race condition in `XLiffBody.AddTransUnitRaw` where two concurrent threads with the same translation-unit ID could both bypass the duplicate check and silently overwrite each other's entry. (#150)
+- [L10NSharp] Eliminated unnecessary cross-instance lock contention in `XLiffBody` by making `_transUnitIdLock` instance-level instead of static. (#150)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [L10NSharp.Windows.Forms] Restored project-local Resources support for `FallbackLanguagesDlgBase` button images (`Move`, `Move_up`, and `Move_down`).
 - [L10NSharp.Windows.Forms] Corrected resource manager base name to `L10NSharp.Windows.Forms.Properties.Resources`.
 - [L10NSharp.Windows.Forms.Tests] Corrected resource manager base name to `L10NSharp.Windows.Forms.Tests.Properties.Resources`.
+- [L10NSharp] Fixed race condition in `XLiffBody.AddTransUnitRaw` where two concurrent threads with the same translation-unit ID could both bypass the duplicate check and silently overwrite each other's entry. (#150)
 
 ### Removed
 

--- a/src/L10NSharp/XLiffUtils/XLiffBody.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffBody.cs
@@ -219,7 +219,8 @@ namespace L10NSharp.XLiffUtils
 			if (tu == null || tu.Id == null)
 				return;
 
-			// No SpinLock needed: _transUnitIdLock guards ID assignment, not the dictionary itself.
+			// No SpinLock needed: _transUnitIdLock serializes AddTransUnitRaw's check-then-add
+			// sequence; TryRemove is independently atomic.
 			_transUnitDict.TryRemove(tu.Id, out _);
 			TranslationsById.TryRemove(tu.Id, out _);
 		}

--- a/src/L10NSharp/XLiffUtils/XLiffBody.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffBody.cs
@@ -219,6 +219,7 @@ namespace L10NSharp.XLiffUtils
 			if (tu == null || tu.Id == null)
 				return;
 
+			// No SpinLock needed: _transUnitIdLock guards ID assignment, not the dictionary itself.
 			_transUnitDict.TryRemove(tu.Id, out _);
 			TranslationsById.TryRemove(tu.Id, out _);
 		}

--- a/src/L10NSharp/XLiffUtils/XLiffBody.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffBody.cs
@@ -152,7 +152,7 @@ namespace L10NSharp.XLiffUtils
 				key = tu.Id;
 				if (string.IsNullOrEmpty(key))
 				{
-					tu.Id = (System.Threading.Interlocked.Increment(ref _transUnitId)).ToString();
+					tu.Id = (++_transUnitId).ToString();
 					key = tu.Id;
 				}
 

--- a/src/L10NSharp/XLiffUtils/XLiffBody.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffBody.cs
@@ -25,7 +25,7 @@ namespace L10NSharp.XLiffUtils
 		// This is used when translation unit IDs are not found in the file (which seems to be
 		// the case with Lingobit XLiff files).
 		private int _transUnitId;
-		static SpinLock _transUnitIdLock;
+		SpinLock _transUnitIdLock;
 
 		private readonly ConcurrentDictionary<string, XLiffTransUnit> _transUnitDict =
 			new ConcurrentDictionary<string, XLiffTransUnit>();

--- a/src/L10NSharp/XLiffUtils/XLiffBody.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffBody.cs
@@ -155,16 +155,19 @@ namespace L10NSharp.XLiffUtils
 					tu.Id = (System.Threading.Interlocked.Increment(ref _transUnitId)).ToString();
 					key = tu.Id;
 				}
+
+				// If a translation unit with the specified id already exists, then quit here.
+				// This check and the dictionary write must both happen inside the lock to avoid
+				// a TOCTOU race where two threads with the same ID both pass the check.
+				if (GetTransUnitForId(key) != null)
+					return false;
+				_transUnitDict[key] = tu;
 			}
 			finally
 			{
 				if (lockTaken) _transUnitIdLock.Exit(false);
 			}
 
-			// If a translation unit with the specified id already exists, then quit here.
-			if (GetTransUnitForId(tu.Id) != null)
-				return false;
-			_transUnitDict[key] = tu;
 			return true;
 		}
 		public bool AddTransUnit(XLiffTransUnit tu)


### PR DESCRIPTION
## Summary
- Moves the duplicate-ID check and `_transUnitDict` write inside the `SpinLock` try block, closing the TOCTOU window where two threads with the same ID could both pass the check and silently overwrite each other's entry
- Makes `_transUnitIdLock` instance-level (removes `static`) so concurrent operations on different `XLiffBody` instances no longer contend on a shared lock
- Replaces `Interlocked.Increment` with `++` inside the SpinLock critical section, where the lock already provides mutual exclusion
- Documents in `RemoveTransUnit` why `_transUnitIdLock` is intentionally not acquired there

Closes #150

Devin review: https://app.devin.ai/review/sillsdev/l10nsharp/pull/154

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/154)
<!-- Reviewable:end -->
