### PR TITLE
migrate core library to use nullable reference types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [L10NSharp.Windows.Forms] Removed emailForSubmissions parameter (8th parameter) from LocalizationManagerWinforms.Create. Since the localization dialog was jettisoned, it no longer makes sense to store this information on the localization manager.
 - [L10NSharp] Replaced the .NET 8.0 target with .NET Standard 2.0 for broader compatibility.
 - [L10NSharp] `GetDynamicString`, `GetDynamicStringOrEnglish`, and `GetString` now return the English fallback text immediately when called with a null, empty, or whitespace string ID, rather than attempting a cache lookup or write.
- 
+- [L10NSharp] Enabled nullable reference types on the core project with full CS86xx warning cleanup across all layers; `ILocalizedStringCache` and `ILocalizationManagerInternal` gained nullable annotations that may require source updates for NRT consumers.
+
 ### Fixed
 
 - [L10NSharp.Windows.Forms] Restored project-local Resources support for `FallbackLanguagesDlgBase` button images (`Move`, `Move_up`, and `Move_down`).

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,7 @@ See full changelog at https://github.com/sillsdev/l10nsharp/blob/master/CHANGELO
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Without this line some projects fail to build on TC with "error : SourceRoot items

--- a/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
+++ b/src/L10NSharp.Tests/LocalizationManagerTestsBase.cs
@@ -11,7 +11,7 @@ using NUnit.Framework;
 
 namespace L10NSharp.Tests
 {
-	public abstract class LocalizationManagerTestsBase<T> where T : IDocument
+	public abstract class LocalizationManagerTestsBase<T> where T : class, IDocument
 	{
 		protected const string AppId = "test";
 		protected const string AppName = "unit test";

--- a/src/L10NSharp.Windows.Forms/ILocalizationManagerInternalWinforms.cs
+++ b/src/L10NSharp.Windows.Forms/ILocalizationManagerInternalWinforms.cs
@@ -20,7 +20,7 @@ namespace L10NSharp.Windows.Forms
 			Action<ILocalizationManagerInternalWinforms, LocalizingInfoWinforms> successAction);
 	}
 
-	internal interface ILocalizationManagerInternalWinforms<T> : ILocalizationManagerInternalWinforms, ILocalizationManagerInternal<T>
+	internal interface ILocalizationManagerInternalWinforms<T> : ILocalizationManagerInternalWinforms, ILocalizationManagerInternal<T> where T : class
 	{
 		new ILocalizedStringCacheWinforms<T> StringCache { get; }
 	}

--- a/src/L10NSharp.Windows.Forms/ILocalizedStringCacheWinforms.cs
+++ b/src/L10NSharp.Windows.Forms/ILocalizedStringCacheWinforms.cs
@@ -4,7 +4,7 @@ using L10NSharp.Windows.Forms.UIComponents;
 
 namespace L10NSharp.Windows.Forms
 {
-	internal interface ILocalizedStringCacheWinforms<T> : L10NSharp.ILocalizedStringCache<T>
+	internal interface ILocalizedStringCacheWinforms<T> : L10NSharp.ILocalizedStringCache<T> where T : class
 	{
 		List<LocTreeNode<T>> LeafNodeList { get; }
 		Keys GetShortcutKeys(string langId, string id);

--- a/src/L10NSharp.Windows.Forms/LocalizationManagerInternalWinforms.cs
+++ b/src/L10NSharp.Windows.Forms/LocalizationManagerInternalWinforms.cs
@@ -13,7 +13,7 @@ using L10NSharp.Windows.Forms.UIComponents;
 
 namespace L10NSharp.Windows.Forms
 {
-	internal class LocalizationManagerInternalWinforms<T> : LocalizationManagerInternal<T>
+	internal class LocalizationManagerInternalWinforms<T> : LocalizationManagerInternal<T> where T : class
 	{
 
 		/// <summary>

--- a/src/L10NSharp.Windows.Forms/UIComponents/FallbackLanguagesDlg.cs
+++ b/src/L10NSharp.Windows.Forms/UIComponents/FallbackLanguagesDlg.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace L10NSharp.Windows.Forms.UIComponents
 {
-	public class FallbackLanguagesDlg<T> : FallbackLanguagesDlgBase
+	public class FallbackLanguagesDlg<T> : FallbackLanguagesDlgBase where T : class
 	{
 		public FallbackLanguagesDlg()
 		{

--- a/src/L10NSharp.Windows.Forms/UIComponents/LocTreeNode.cs
+++ b/src/L10NSharp.Windows.Forms/UIComponents/LocTreeNode.cs
@@ -5,7 +5,7 @@ using System.Windows.Forms;
 namespace L10NSharp.Windows.Forms.UIComponents
 {
 	/// ----------------------------------------------------------------------------------------
-	internal class LocTreeNode<T> : TreeNode
+	internal class LocTreeNode<T> : TreeNode where T : class
 	{
 		internal string Group { get; set; }
 		internal string Id { get; private set; }

--- a/src/L10NSharp.Windows.Forms/UIComponents/NodeComparer.cs
+++ b/src/L10NSharp.Windows.Forms/UIComponents/NodeComparer.cs
@@ -5,7 +5,7 @@ using System.Windows.Forms;
 namespace L10NSharp.Windows.Forms.UIComponents
 {
 	/// ----------------------------------------------------------------------------------------
-	internal class NodeComparer<T> : IComparer<LocTreeNode<T>>
+	internal class NodeComparer<T> : IComparer<LocTreeNode<T>> where T : class
 	{
 		internal enum SortField
 		{

--- a/src/L10NSharp/CodeReader/ILReader.cs
+++ b/src/L10NSharp/CodeReader/ILReader.cs
@@ -10,10 +10,10 @@ namespace L10NSharp.CodeReader
 	internal class ILInstruction
 	{
 		public readonly OpCode opCode;
-		public readonly object operand;
+		public readonly object? operand;
 
 		/// ------------------------------------------------------------------------------------
-		public ILInstruction(OpCode opCode, object operand)
+		public ILInstruction(OpCode opCode, object? operand)
 		{
 			this.opCode = opCode;
 			this.operand = operand;
@@ -94,7 +94,7 @@ namespace L10NSharp.CodeReader
 				opCode = s_TwoByteOpCodes[code];
 			}
 
-			object operand = null;
+			object? operand = null;
 
 			switch (opCode.OperandType)
 			{

--- a/src/L10NSharp/CodeReader/StringExtractor.cs
+++ b/src/L10NSharp/CodeReader/StringExtractor.cs
@@ -15,10 +15,10 @@ namespace L10NSharp.CodeReader
 	/// ------------------------------------------------------------------------------------
 	public class StringExtractor<T>
 	{
-		private MethodInfo[] _getStringMethodOverloads;
-		private List<LocalizingInfo> _getStringCallsInfo;
-		private Dictionary<string, LocalizingInfo> _extenderInfo;
-		private List<ILInstruction> _instructions;
+		private MethodInfo[] _getStringMethodOverloads = Array.Empty<MethodInfo>();
+		private List<LocalizingInfo> _getStringCallsInfo = new List<LocalizingInfo>();
+		private Dictionary<string, LocalizingInfo> _extenderInfo = new Dictionary<string, LocalizingInfo>();
+		private List<ILInstruction> _instructions = new List<ILInstruction>();
 		private readonly HashSet<string> _scannedTypes = new HashSet<string>();
 
 		public List<string> ExtractionExceptions = new List<string>();
@@ -34,8 +34,8 @@ namespace L10NSharp.CodeReader
 
 		/// ------------------------------------------------------------------------------------
 		public IReadOnlyList<LocalizingInfo> DoExtractingWork(
-			IEnumerable<MethodInfo> additionalLocalizationMethods,
-			string[] namespaceBeginnings, BackgroundWorker worker)
+			IEnumerable<MethodInfo>? additionalLocalizationMethods,
+			string[] namespaceBeginnings, BackgroundWorker? worker)
 		{
 			_getStringMethodOverloads = typeof(LocalizationManager)
 				.GetMethods(BindingFlags.Static | BindingFlags.Public)
@@ -43,7 +43,7 @@ namespace L10NSharp.CodeReader
 				.Union(typeof(L10NStringExtensions)
 				.GetMethods(BindingFlags.Static | BindingFlags.Public)
 				.Where(m => m.Name == "Localize"))
-				.Union(additionalLocalizationMethods ?? new MethodInfo[0])
+				.Union(additionalLocalizationMethods ?? Array.Empty<MethodInfo>())
 				.ToArray();
 
 			_getStringCallsInfo = new List<LocalizingInfo>();
@@ -193,7 +193,7 @@ namespace L10NSharp.CodeReader
 
 				foreach (var type in typesInAssembly
 					.Where(t => t != null && !typesToScan.Contains(t))
-					.Where(type => namespaceBeginnings.Count == 0 || namespaceBeginnings.Any(nsb => type.FullName.StartsWith(nsb))))
+					.Where(type => namespaceBeginnings.Count == 0 || namespaceBeginnings.Any(nsb => type.FullName?.StartsWith(nsb) ?? false)))
 				{
 					typesToScan.Add(type);
 				}
@@ -208,13 +208,13 @@ namespace L10NSharp.CodeReader
 			/// ------------------------------------------------------------------------------------
 			public bool Equals(LocalizingInfo x, LocalizingInfo y)
 			{
-				return x.Id.Equals(y.Id, StringComparison.Ordinal);
+				return string.Equals(x.Id, y.Id, StringComparison.Ordinal);
 			}
 
 			/// ------------------------------------------------------------------------------------
 			public int GetHashCode(LocalizingInfo obj)
 			{
-				return obj.Id.GetHashCode();
+				return obj.Id?.GetHashCode() ?? 0;
 			}
 		}
 
@@ -224,7 +224,7 @@ namespace L10NSharp.CodeReader
 		/// If this is set, no other loaded assemblies are scanned.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public Assembly[] ExternalAssembliesToScan;
+		public Assembly[]? ExternalAssembliesToScan;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -300,7 +300,6 @@ namespace L10NSharp.CodeReader
 #endif
 				try
 				{
-					_instructions = new List<ILInstruction>(new ILReader<T>(method));
 
 					var methodCallsInMethod = GetMethodCalls(method);
 					foreach (var getStringOverload in _getStringMethodOverloads)
@@ -328,6 +327,7 @@ namespace L10NSharp.CodeReader
 		/// ------------------------------------------------------------------------------------
 		private List<Tuple<int, MethodBase>> GetMethodCalls(MethodBase caller)
 		{
+			_instructions = new List<ILInstruction>(new ILReader<T>(caller));
 			var methodCalls = new List<Tuple<int, MethodBase>>();
 			var module = caller.Module;
 
@@ -336,8 +336,8 @@ namespace L10NSharp.CodeReader
 				if (_instructions[i].opCode != OpCodes.Call)
 					continue;
 
-				Type[] genericMethodArguments = null;
-				var genericTypeArguments = caller.DeclaringType.GetGenericArguments();
+				Type[]? genericMethodArguments = null;
+				var genericTypeArguments = caller.DeclaringType!.GetGenericArguments();
 
 				if (!caller.IsConstructor && !caller.Name.Equals(".cctor"))
 					genericMethodArguments = caller.GetGenericArguments();
@@ -345,7 +345,7 @@ namespace L10NSharp.CodeReader
 				try
 				{
 					methodCalls.Add(new Tuple<int, MethodBase>(i,
-						module.ResolveMethod((int)_instructions[i].operand,
+						module.ResolveMethod((int)_instructions[i].operand!,
 						genericTypeArguments, genericMethodArguments)));
 				}
 				catch (FileNotFoundException e1)
@@ -388,7 +388,7 @@ namespace L10NSharp.CodeReader
 		/// This is special because, as an extension method the 1st parameter in "hello".Localize("myapp.greeting") will be the string ("hello") itself,
 		/// which is backwards from the convention used in the GetString(id, theString, etc.)
 		/// </summary>
-		private LocalizingInfo GetInfoForCallToLocalizeExtension(Module module, int instrIndex, int paramsInMethodCall)
+		private LocalizingInfo? GetInfoForCallToLocalizeExtension(Module module, int instrIndex, int paramsInMethodCall)
 		{
 			var parameters = GetParameters(module, instrIndex, paramsInMethodCall);
 
@@ -399,7 +399,7 @@ namespace L10NSharp.CodeReader
 
 			var id = String.IsNullOrEmpty(parameters[1]) ? parameters[0] : parameters[1];
 
-			var locInfo = new LocalizingInfo(id) { Text = parameters[0] };
+			var locInfo = new LocalizingInfo(id!) { Text = parameters[0] };
 
 			//end part that differs from GetInfoForCallToLocalizationMethod
 
@@ -417,14 +417,14 @@ namespace L10NSharp.CodeReader
 			return locInfo;
 		}
 
-		private string[] GetParameters(Module module, int instrIndex, int paramsInMethodCall)
+		private string?[] GetParameters(Module module, int instrIndex, int paramsInMethodCall)
 		{
 			int parameterIndex = paramsInMethodCall - 1;
-			var parameters = new string[paramsInMethodCall];
+			var parameters = new string?[paramsInMethodCall];
 			for (int i = 1; ; i++)
 			{
 				if (_instructions[instrIndex - i].opCode == OpCodes.Ldstr)
-					parameters[parameterIndex--] = module.ResolveString((int) _instructions[instrIndex - i].operand);
+					parameters[parameterIndex--] = module.ResolveString((int)_instructions[instrIndex - i].operand!);
 				else if (_instructions[instrIndex - i].opCode != OpCodes.Call)
 				{
 					parameterIndex--;
@@ -439,7 +439,7 @@ namespace L10NSharp.CodeReader
 		}
 
 		/// ------------------------------------------------------------------------------------
-		private LocalizingInfo GetInfoForCallToGetStringMethod(Module module,
+		private LocalizingInfo? GetInfoForCallToGetStringMethod(Module module,
 			int instrIndex, int paramsInMethodCall)
 		{
 			var parameters = GetParameters(module, instrIndex, paramsInMethodCall);
@@ -447,7 +447,7 @@ namespace L10NSharp.CodeReader
 			if (parameters[0] == null || parameters[1] == null)
 				return null;
 
-			var locInfo = new LocalizingInfo(parameters[0]) { Text = parameters[1] };
+			var locInfo = new LocalizingInfo(parameters[0]!) { Text = parameters[1]! };
 
 			if (paramsInMethodCall >= 3 && parameters[2] != null)
 				locInfo.Comment = parameters[2];
@@ -470,11 +470,11 @@ namespace L10NSharp.CodeReader
 
 			for (int i = 1; i < _instructions.Count; i++)
 			{
-				string text = null;
+				string? text;
 
 				if (_instructions[i].opCode == OpCodes.Ldstr)
 				{
-					text = module.ResolveString((int)_instructions[i].operand);
+					text = module.ResolveString((int)_instructions[i].operand!);
 					if (text.StartsWith(LocalizationManager.kL10NPrefix))
 					{
 						var locInfo = GetLocInfoForField(caller.ReflectedType.Name, text);
@@ -494,18 +494,18 @@ namespace L10NSharp.CodeReader
 				if (_instructions[i - 1].opCode == OpCodes.Ldnull)
 					continue;
 
-				Type[] genericMethodArguments = null;
-				var genericTypeArguments = caller.DeclaringType.GetGenericArguments();
+				Type[]? genericMethodArguments = null;
+				var genericTypeArguments = caller.DeclaringType!.GetGenericArguments();
 
 				if (!caller.IsConstructor && !caller.Name.Equals(".cctor"))
 					genericMethodArguments = caller.GetGenericArguments();
 
-				string fldName = null;
+				string? fldName;
 
-				MethodBase mi = null;
+				MethodBase? mi;
 				try
 				{
-					mi = module.ResolveMethod((int)_instructions[i].operand,
+					mi = module.ResolveMethod((int)_instructions[i].operand!,
 						genericTypeArguments, genericMethodArguments);
 
 				}
@@ -516,6 +516,9 @@ namespace L10NSharp.CodeReader
 					continue;
 				}
 
+				if (mi == null)
+					continue;
+
 				if (mi.Name.Equals("SetLocalizationPriority", StringComparison.Ordinal))
 				{
 					var priority = (LocalizationPriority)(_instructions[i - 1].opCode.Value - 22);
@@ -525,7 +528,7 @@ namespace L10NSharp.CodeReader
 				}
 
 				text = (i > 1 && _instructions[i - 1].opCode == OpCodes.Ldstr ?
-					module.ResolveString((int)_instructions[i - 1].operand) : null);
+					module.ResolveString((int)_instructions[i - 1].operand!) : null);
 
 				if (text == null)
 					continue;
@@ -557,7 +560,7 @@ namespace L10NSharp.CodeReader
 		private string GetFieldName(Module module, ILInstruction instruction)
 		{
 			if (instruction.opCode == OpCodes.Ldfld)
-				return module.ResolveField((int)instruction.operand).Name;
+				return module.ResolveField((int)instruction.operand!).Name;
 
 			return (instruction.opCode == OpCodes.Ldarg_0 ? "Form" : "throwaway");
 		}

--- a/src/L10NSharp/ILocalizationManager.cs
+++ b/src/L10NSharp/ILocalizationManager.cs
@@ -92,6 +92,6 @@ namespace L10NSharp
 		/// Gets the localized text for the specified id.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		string GetLocalizedString(string id, string defaultText);
+		string GetLocalizedString(string id, string? defaultText);
 	}
 }

--- a/src/L10NSharp/ILocalizationManagerInternal.cs
+++ b/src/L10NSharp/ILocalizationManagerInternal.cs
@@ -8,14 +8,14 @@ namespace L10NSharp
 	{
 		Dictionary<IComponent, string> ComponentCache { get; }
 
-		string GetStringFromStringCache(string uiLangId, string id);
+		string? GetStringFromStringCache(string uiLangId, string id);
 
-		void SaveIfDirty(ICollection<string> langIdsToForceCreate);
-		string GetPathForLanguage(string langId, bool getCustomPathEvenIfNonexistent);
+		void SaveIfDirty(ICollection<string>? langIdsToForceCreate);
+		string? GetPathForLanguage(string langId, bool getCustomPathEvenIfNonexistent);
 		void HandleUiLanguageChange();
 	}
 
-	internal interface ILocalizationManagerInternal<T>: ILocalizationManagerInternal
+	internal interface ILocalizationManagerInternal<T> : ILocalizationManagerInternal where T : class
 	{
 		ILocalizedStringCache<T> StringCache { get; }
 		/// <summary>

--- a/src/L10NSharp/ILocalizedStringCache.cs
+++ b/src/L10NSharp/ILocalizedStringCache.cs
@@ -1,18 +1,19 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace L10NSharp
 {
-	internal interface ILocalizedStringCache<T>
+	internal interface ILocalizedStringCache<T> where T : class
 	{
-		bool TryGetDocument(string langId, out T doc);
+		bool TryGetDocument(string langId, [NotNullWhen(true)] out T? doc);
 		IEnumerable<string> AvailableLangKeys { get; }
-		string GetString(string langId, string id);
-		string GetString(string langId, string id, bool formatForDisplay);
-		string GetToolTipText(string langId, string id);
-		string GetToolTipText(string langId, string id, bool formatForDisplay);
-		string GetShortcutKeysText(string langId, string id);
-		string GetComment(string id);
-		string GetValueForExactLangAndId(string langId, string id, bool formatForDisplay);
+		string? GetString(string langId, string id);
+		string? GetString(string langId, string id, bool formatForDisplay);
+		string? GetToolTipText(string langId, string id);
+		string? GetToolTipText(string langId, string id, bool formatForDisplay);
+		string? GetShortcutKeysText(string langId, string id);
+		string? GetComment(string id);
+		string? GetValueForExactLangAndId(string langId, string id, bool formatForDisplay);
 
 		void UpdateLocalizedInfo(LocalizingInfo locInfo);
 

--- a/src/L10NSharp/L10NCultureInfo.cs
+++ b/src/L10NSharp/L10NCultureInfo.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using static System.StringComparison;
@@ -93,7 +94,7 @@ namespace L10NSharp
 			}
 			else
 			{
-				InitializeFromRawCultureInfo();
+				InitializeFromRawCultureInfo(RawCultureInfo);
 				// The Windows .Net runtime returns 'Azərbaycan dili (Azərbaycan)' for az-Latn, and
 				// something totally different for az.
 				// The Mono runtime returns "azərbaycan" for both az and az-Latn.
@@ -109,26 +110,27 @@ namespace L10NSharp
 		private L10NCultureInfo(CultureInfo ci)
 		{
 			RawCultureInfo = ci;
-			InitializeFromRawCultureInfo();
+			InitializeFromRawCultureInfo(ci);
 		}
 
-		private void InitializeFromRawCultureInfo()
+		[MemberNotNull(nameof(EnglishName), nameof(DisplayName), nameof(NativeName), nameof(IsNeutralCulture), nameof(NumberFormat), nameof(Name), nameof(TwoLetterISOLanguageName), nameof(ThreeLetterISOLanguageName), nameof(IetfLanguageTag))]
+		private void InitializeFromRawCultureInfo(CultureInfo rawCultureInfo)
 		{
-			EnglishName = RawCultureInfo.EnglishName;
-			DisplayName = RawCultureInfo.DisplayName;
-			NativeName = RawCultureInfo.NativeName;
-			IsNeutralCulture = RawCultureInfo.IsNeutralCulture;
-			NumberFormat = RawCultureInfo.NumberFormat;
-			Name = RawCultureInfo.Name;
-			TwoLetterISOLanguageName = RawCultureInfo.TwoLetterISOLanguageName;
-			ThreeLetterISOLanguageName = RawCultureInfo.ThreeLetterISOLanguageName;
-			IetfLanguageTag = RawCultureInfo.IetfLanguageTag;
+			EnglishName = rawCultureInfo.EnglishName;
+			DisplayName = rawCultureInfo.DisplayName;
+			NativeName = rawCultureInfo.NativeName;
+			IsNeutralCulture = rawCultureInfo.IsNeutralCulture;
+			NumberFormat = rawCultureInfo.NumberFormat;
+			Name = rawCultureInfo.Name;
+			TwoLetterISOLanguageName = rawCultureInfo.TwoLetterISOLanguageName;
+			ThreeLetterISOLanguageName = rawCultureInfo.ThreeLetterISOLanguageName;
+			IetfLanguageTag = rawCultureInfo.IetfLanguageTag;
 		}
 
 		/// <summary>
 		/// Provide access to the underlying CultureInfo object if it exists.
 		/// </summary>
-		public CultureInfo RawCultureInfo { get; }
+		public CultureInfo? RawCultureInfo { get; }
 
 		// The following properties mimic those provided by CultureInfo.
 
@@ -150,7 +152,7 @@ namespace L10NSharp
 
 		public NumberFormatInfo NumberFormat { get; set; }
 
-		private static L10NCultureInfo _currentInfo;
+		private static L10NCultureInfo? _currentInfo;
 		public static L10NCultureInfo CurrentCulture
 		{
 			get
@@ -221,7 +223,7 @@ namespace L10NSharp
 			return $"[L10NCultureInfo: Name={Name}, EnglishName={EnglishName}]";
 		}
 
-		public static bool operator ==(L10NCultureInfo ci1, L10NCultureInfo ci2)
+		public static bool operator ==(L10NCultureInfo? ci1, L10NCultureInfo? ci2)
 		{
 			if (ReferenceEquals(ci1, ci2))
 				return true;
@@ -233,7 +235,7 @@ namespace L10NSharp
 		}
 
 		// this is second one '!='
-		public static bool operator !=(L10NCultureInfo ci1, L10NCultureInfo ci2)
+		public static bool operator !=(L10NCultureInfo? ci1, L10NCultureInfo? ci2)
 		{
 			return !(ci1 == ci2);
 		}

--- a/src/L10NSharp/L10NSharp.csproj
+++ b/src/L10NSharp/L10NSharp.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Nullable>enable</Nullable>
     <TargetFrameworks>$(TargetFrameworks);netstandard2.0</TargetFrameworks>
     <RootNamespace>L10NSharp</RootNamespace>
     <Description>L10NSharp is a .NET localization library. It collects strings which need localization when your application first runs and saves them in a XLIFF file.</Description>
@@ -13,6 +14,10 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
+    <PackageReference Include="PolySharp" Version="1.16.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
     <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
   </ItemGroup>

--- a/src/L10NSharp/LocalizationManager.cs
+++ b/src/L10NSharp/LocalizationManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
@@ -17,7 +18,7 @@ namespace L10NSharp
 		internal const string kL10NPrefix = "_L10N_:";
 		internal const string kAppVersionPropTag = "x-appversion";
 
-		private static string s_uiLangId;
+		private static string? s_uiLangId;
 		internal static TranslationMemory TranslationMemoryKind { get; set; }
 
 		/// <summary>
@@ -82,7 +83,7 @@ namespace L10NSharp
 			string appId, string appName, string appVersion, string directoryOfInstalledFiles,
 			string relativeSettingPathForLocalizationFolder,
 			string[] namespaceBeginnings,
-			IEnumerable<MethodInfo> additionalLocalizationMethods = null)
+			IEnumerable<MethodInfo>? additionalLocalizationMethods = null)
 		{
 			TranslationMemoryKind = TranslationMemory.XLiff;
 			return LocalizationManagerInternal<XLiffDocument>.CreateXliff(desiredUiLangId,
@@ -449,8 +450,8 @@ namespace L10NSharp
 		/// policy for this library.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public static string GetString(string stringId, string englishText, string comment,
-			IEnumerable<string> preferredLanguageIds, out string languageIdUsed)
+		public static string GetString(string stringId, string englishText, string? comment,
+			IEnumerable<string> preferredLanguageIds, out string? languageIdUsed)
 		{
 			switch (TranslationMemoryKind)
 			{
@@ -603,7 +604,8 @@ namespace L10NSharp
 			}
 		}
 
-		public static string StripOffLocalizationInfoFromText(string text)
+		[return: NotNullIfNotNull("text")]
+		public static string? StripOffLocalizationInfoFromText(string? text)
 		{
 			if (text == null || !text.StartsWith(kL10NPrefix))
 				return text;

--- a/src/L10NSharp/LocalizationManagerInternal.cs
+++ b/src/L10NSharp/LocalizationManagerInternal.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -11,10 +12,10 @@ using L10NSharp.XLiffUtils;
 
 namespace L10NSharp
 {
-	internal class LocalizationManagerInternal<T>
+	internal class LocalizationManagerInternal<T> where T : class
 	{
 		protected static List<string> s_fallbackLanguageIds =
-			new List<string>(new[] { LocalizationManager.kDefaultLang });
+			new List<string> { LocalizationManager.kDefaultLang };
 
 		/// <summary>
 		/// Map from the given language code to a variant we actually have.  (It can map from a
@@ -139,7 +140,7 @@ namespace L10NSharp
 		public static ILocalizationManager CreateXliff(string desiredUiLangId, string appId,
 			string appName, string appVersion, string directoryOfInstalledXliffFiles,
 			string relativeSettingPathForLocalizationFolder,
-			IEnumerable<MethodInfo> additionalLocalizationMethods,
+			IEnumerable<MethodInfo>? additionalLocalizationMethods,
 			params string[] namespaceBeginnings)
 		{
 			if (string.IsNullOrWhiteSpace(appId))
@@ -174,14 +175,14 @@ namespace L10NSharp
 		}
 
 		/// ------------------------------------------------------------------------------------
-		internal static ILocalizationManagerInternal<T> GetLocalizationManagerForComponent(
+		internal static ILocalizationManagerInternal<T>? GetLocalizationManagerForComponent(
 			IComponent component)
 		{
 			return LoadedManagers.Values.FirstOrDefault(lm => lm.ComponentCache.ContainsKey(component));
 		}
 
 		/// ------------------------------------------------------------------------------------
-		internal static ILocalizationManagerInternal<T> GetLocalizationManagerForString(string id)
+		internal static ILocalizationManagerInternal<T>? GetLocalizationManagerForString(string id)
 		{
 			return LoadedManagers.Values.FirstOrDefault(
 				lm => lm.StringCache.GetString(LocalizationManager.UILanguageId, id) != null);
@@ -327,7 +328,7 @@ namespace L10NSharp
 					// (short of at least a major change of API).
 					return null; // to the Select; filtered out below
 				}
-			}).Where(ci => ci != null));
+			}).OfType<L10NCultureInfo>());
 
 			if (!returnOnlyLanguagesHavingLocalizations)
 				return from ci in allLangs
@@ -424,7 +425,7 @@ namespace L10NSharp
 		/// for the specified object cannot be found for the current UI language.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public static string GetStringForObject(IComponent component, string englishText)
+		public static string GetStringForObject(IComponent component, string? englishText)
 		{
 			var lm = GetLocalizationManagerForComponent(component);
 
@@ -435,7 +436,7 @@ namespace L10NSharp
 			}
 
 			return LocalizationManager.StripOffLocalizationInfoFromText(
-				englishText ?? Utils.GetProperty(component, "Text") as string);
+				englishText ?? Utils.GetProperty(component, "Text") as string) ?? string.Empty;
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -459,7 +460,7 @@ namespace L10NSharp
 		/// language.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public static string GetDynamicString(string appId, string id, string englishText, string comment)
+		public static string GetDynamicString(string appId, string id, string englishText, string? comment)
 		{
 			return GetDynamicStringOrEnglish(appId, id, englishText, comment, LocalizationManager.UILanguageId);
 		}
@@ -476,11 +477,11 @@ namespace L10NSharp
 		/// langId = 'en', irrespective of what is in l10n file.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public static string GetDynamicStringOrEnglish(string appId, string id, string englishText,
-			string comment, string langId)
+		public static string GetDynamicStringOrEnglish(string appId, string id, string? englishText,
+			string? comment, string langId)
 		{
 			if (string.IsNullOrWhiteSpace(id))
-				return string.IsNullOrEmpty(englishText) ? string.Empty : englishText;
+				return string.IsNullOrEmpty(englishText) ? string.Empty : englishText!;
 			// This happens in unit test environments or apps that have imported a library that
 			// is localized, but the app itself isn't initializing L10N yet.
 			if (LoadedManagers.Count == 0)
@@ -492,11 +493,11 @@ namespace L10NSharp
 						throw new ObjectDisposedException(
 							$"The application id '{appId}' refers to a LocalizationManagerInternal that has been disposed");
 					}
-					return string.IsNullOrEmpty(englishText) ? id : englishText;
+					return string.IsNullOrEmpty(englishText) ? id : englishText!;
 				}
 
 				if (!string.IsNullOrEmpty(englishText) && langId == LocalizationManager.kDefaultLang)
-					return englishText;
+					return englishText!;
 				return id;
 			}
 			if (!LoadedManagers.TryGetValue(appId, out var lm))
@@ -509,7 +510,7 @@ namespace L10NSharp
 							$"The application id '{appId}' refers to a LocalizationManagerInternal that has been disposed");
 					}
 
-					return string.IsNullOrEmpty(englishText) ? id : englishText;
+					return string.IsNullOrEmpty(englishText) ? id : englishText!;
 				}
 				throw new ArgumentException(
 					$"The application id '{appId}' does not have an associated localization manager. " +
@@ -529,7 +530,7 @@ namespace L10NSharp
 			}
 
 			if (!lm.CollectUpNewStringsDiscoveredDynamically)
-				return englishText;
+				return englishText ?? string.Empty;
 
 			var locInfo = new LocalizingInfo(id)
 			{
@@ -547,7 +548,7 @@ namespace L10NSharp
 
 			lm.StringCache.UpdateLocalizedInfo(locInfo);
 			lm.SaveIfDirty(null);// this will be common for GetDynamic string on users restricted from writing to ProgramData
-			return englishText;
+			return englishText ?? string.Empty;
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -562,9 +563,10 @@ namespace L10NSharp
 		/// <remarks>
 		/// <see cref="XliffLocalizedStringCache.LoadXliffAndUpdateExistingLanguageMap"/> must load "es-ES" before "es" will map to "es-ES".
 		/// </remarks>
-		internal static string MapToExistingLanguageIfPossible(string langId)
+		[return: NotNullIfNotNull("langId")]
+		internal static string? MapToExistingLanguageIfPossible(string? langId)
 		{
-			if (string.IsNullOrEmpty(langId))
+			if (langId is null || string.IsNullOrEmpty(langId))
 				return null;
 			// It's a concurrent dictionary, so we can (for performance) try this without a lock.
 			if (MapToExistingLanguage.TryGetValue(langId, out var realId))
@@ -618,7 +620,7 @@ namespace L10NSharp
 		}
 
 		/// ------------------------------------------------------------------------------------
-		internal static string GetStringFromAnyLocalizationManager(string stringId)
+		internal static string? GetStringFromAnyLocalizationManager(string stringId)
 		{
 			if (LocalizationManager.StrictInitializationMode)
 			{
@@ -641,8 +643,8 @@ namespace L10NSharp
 		}
 
 		/// ------------------------------------------------------------------------------------
-		internal static string GetStringFromAnyLocalizationManager(string stringId,
-			IEnumerable<string> preferredLanguageIds, out string languageIdUsed)
+		internal static string? GetStringFromAnyLocalizationManager(string stringId,
+			IEnumerable<string> preferredLanguageIds, out string? languageIdUsed)
 		{
 			foreach (var langId in preferredLanguageIds)
 			{
@@ -654,7 +656,7 @@ namespace L10NSharp
 			return null;
 		}
 
-		protected static string MapToExistingLanguageOrAddMapping(string stringId, string langId,
+		protected static string? MapToExistingLanguageOrAddMapping(string stringId, string langId,
 			out string languageIdUsed)
 		{
 			var realLangId = MapToExistingLanguageIfPossible(langId);
@@ -683,7 +685,7 @@ namespace L10NSharp
 		/// a string cannot be found for the specified id and the current UI language.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public static string GetString(string stringId, string englishText, string comment)
+		public static string GetString(string stringId, string englishText, string? comment)
 		{
 			return GetString(stringId, englishText, comment, null, null, null);
 		}
@@ -694,7 +696,7 @@ namespace L10NSharp
 		/// a string cannot be found for the specified id and the current UI language.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public static string GetString(string stringId, string englishText, string comment, IComponent component)
+		public static string GetString(string stringId, string englishText, string? comment, IComponent? component)
 		{
 			return GetString(stringId, englishText, comment, null, null, component);
 		}
@@ -705,8 +707,8 @@ namespace L10NSharp
 		/// a string cannot be found for the specified id and the current UI language.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public static string GetString(string stringId, string englishText, string comment, string englishToolTipText,
-			string englishShortcutKey, IComponent component)
+		public static string GetString(string stringId, string englishText, string? comment, string? englishToolTipText,
+			string? englishShortcutKey, IComponent? component)
 		{
 			if (string.IsNullOrWhiteSpace(stringId))
 				return LocalizationManager.StripOffLocalizationInfoFromText(englishText);
@@ -722,8 +724,8 @@ namespace L10NSharp
 		/// policy for this library.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public static string GetString(string stringId, string englishText, string comment,
-			IEnumerable<string> preferredLanguageIds, out string languageIdUsed)
+		public static string GetString(string stringId, string englishText, string? comment,
+			IEnumerable<string> preferredLanguageIds, out string? languageIdUsed)
 		{
 			if (string.IsNullOrWhiteSpace(stringId))
 			{
@@ -751,7 +753,7 @@ namespace L10NSharp
 				return LocalizationManager.StripOffLocalizationInfoFromText(englishText);
 			}
 
-			return stringFromAnyLocalizationManager;
+			return stringFromAnyLocalizationManager!;
 		}
 
 		/// <summary>

--- a/src/L10NSharp/LocalizingInfo.cs
+++ b/src/L10NSharp/LocalizingInfo.cs
@@ -99,11 +99,11 @@ namespace L10NSharp
 	/// ----------------------------------------------------------------------------------------
 	public class LocalizingInfo
 	{
-		protected IComponent _component;
-		protected string _id;
-		protected string _text;
-		protected string _shortcutKeys;
-		protected string _comment;
+		protected IComponent? _component;
+		protected string? _id;
+		protected string? _text;
+		protected string? _shortcutKeys;
+		protected string? _comment;
 		protected LocalizationCategory _category = LocalizationCategory.Unspecified;
 
 		#region Constructors
@@ -134,7 +134,7 @@ namespace L10NSharp
 		/// Initializes a new instance of the <see cref="LocalizingInfo"/> class.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public LocalizingInfo(string id)
+		public LocalizingInfo(string? id)
 		{
 			Id = id;
 			Priority = LocalizationPriority.MediumHigh;
@@ -177,7 +177,7 @@ namespace L10NSharp
 		/// Gets or sets the id.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public string Id
+		public string? Id
 		{
 			get
 			{
@@ -195,7 +195,7 @@ namespace L10NSharp
 				}
 				else
 				{
-					_id = _id.Trim().Replace("..", ".");//it happens...
+					_id = _id!.Trim().Replace("..", ".");//it happens...
 				}
 			}
 		}
@@ -205,7 +205,7 @@ namespace L10NSharp
 		/// Gets the component.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		internal IComponent Component
+		internal IComponent? Component
 		{
 			get { return _component; }
 			set
@@ -219,7 +219,7 @@ namespace L10NSharp
 		/// Gets or sets the language id.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public string LangId { get; set; }
+		public string? LangId { get; set; }
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -233,7 +233,7 @@ namespace L10NSharp
 		/// Gets or sets the comment.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public string Comment
+		public string? Comment
 		{
 			get { return _comment; }
 			set { _comment = (value == "null" ? null : value); }
@@ -273,28 +273,28 @@ namespace L10NSharp
 		/// Gets or sets the group.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public string Group { get; set; }
+		public string? Group { get; set; }
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// Gets or sets the tooltip.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public string ToolTipText { get; set; }
+		public string? ToolTipText { get; set; }
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// Gets or sets the shortcutKeys.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public string ShortcutKeys;
+		public string? ShortcutKeys;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// Gets the text of the object.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public string Text
+		public string? Text
 		{
 			get
 			{

--- a/src/L10NSharp/Utility/HttpEncoderFromMono.cs
+++ b/src/L10NSharp/Utility/HttpEncoderFromMono.cs
@@ -33,6 +33,7 @@
 //
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -50,7 +51,7 @@ namespace System.Web.Util
 	{
 		static char[] hexChars = "0123456789abcdef".ToCharArray();
 		static object entitiesLock = new object();
-		static SortedDictionary<string, char> entities;
+		static SortedDictionary<string, char>? entities;
 #if NET_4_0
 		static Lazy <HttpEncoder> defaultEncoder;
 		static Lazy <HttpEncoder> currentEncoderLazy;
@@ -136,7 +137,7 @@ namespace System.Web.Util
 				encodedHeaderValue = EncodeHeaderString(headerValue);
 		}
 
-		static void StringBuilderAppend(string s, ref StringBuilder sb)
+		static void StringBuilderAppend(string s, ref StringBuilder? sb)
 		{
 			if (sb == null)
 				sb = new StringBuilder(s);
@@ -146,7 +147,7 @@ namespace System.Web.Util
 
 		static string EncodeHeaderString(string input)
 		{
-			StringBuilder sb = null;
+			StringBuilder? sb = null;
 			char ch;
 
 			for (int i = 0; i < input.Length; i++)
@@ -257,7 +258,8 @@ namespace System.Web.Util
 			return result.ToArray();
 		}
 
-		internal static string HtmlEncode(string s)
+		[return: NotNullIfNotNull("s")]
+		internal static string? HtmlEncode(string? s)
 		{
 			if (s == null)
 				return null;
@@ -333,7 +335,8 @@ namespace System.Web.Util
 			return output.ToString();
 		}
 
-		internal static string HtmlAttributeEncode(string s)
+		[return: NotNullIfNotNull("s")]
+		internal static string? HtmlAttributeEncode(string? s)
 		{
 #if NET_4_0
 			if (String.IsNullOrEmpty (s))
@@ -390,7 +393,8 @@ namespace System.Web.Util
 			return output.ToString();
 		}
 
-		internal static string HtmlDecode(string s)
+        [return: NotNullIfNotNull("s")]
+		internal static string? HtmlDecode(string? s)
 		{
 			if (s == null)
 				return null;
@@ -657,6 +661,7 @@ namespace System.Web.Util
 				result.WriteByte((byte)c);
 		}
 
+        [MemberNotNull(nameof(entities))]
 		static void InitEntities()
 		{
 			// Build the hash table of HTML entity references.  This list comes

--- a/src/L10NSharp/Utility/HttpUtilityFromMono.cs
+++ b/src/L10NSharp/Utility/HttpUtilityFromMono.cs
@@ -37,6 +37,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using System.Web.Util;
@@ -98,7 +99,8 @@ Actually when we go to net 4, I (hatton) think we can get rid of this. .net 4 cl
 #endif
 		}
 
-		public static string HtmlAttributeEncode (string s)
+        [return: NotNullIfNotNull("s")]
+		public static string? HtmlAttributeEncode (string? s)
 		{
 #if NET_4_0
 			if (s == null)
@@ -113,7 +115,8 @@ Actually when we go to net 4, I (hatton) think we can get rid of this. .net 4 cl
 #endif
 		}
 
-		public static string UrlDecode (string str)
+        [return: NotNullIfNotNull("str")]
+		public static string? UrlDecode (string? str)
 		{
 			return UrlDecode(str, Encoding.UTF8);
 		}
@@ -132,7 +135,8 @@ Actually when we go to net 4, I (hatton) think we can get rid of this. .net 4 cl
 				buf.Add ((byte)ch);
 		}
 
-		public static string UrlDecode (string s, Encoding e)
+        [return: NotNullIfNotNull("s")]
+		public static string? UrlDecode (string? s, Encoding? e)
 		{
 			if (null == s)
 				return null;
@@ -180,7 +184,8 @@ Actually when we go to net 4, I (hatton) think we can get rid of this. .net 4 cl
 
 		}
 
-		public static string UrlDecode (byte [] bytes, Encoding e)
+        [return: NotNullIfNotNull("bytes")]
+		public static string? UrlDecode (byte []? bytes, Encoding e)
 		{
 			if (bytes == null)
 				return null;
@@ -235,7 +240,8 @@ Actually when we go to net 4, I (hatton) think we can get rid of this. .net 4 cl
 			return val;
 		}
 
-		public static string UrlDecode (byte [] bytes, int offset, int count, Encoding e)
+        [return: NotNullIfNotNull("bytes")]
+		public static string? UrlDecode (byte []? bytes, int offset, int count, Encoding e)
 		{
 			if (bytes == null)
 				return null;
@@ -292,11 +298,12 @@ Actually when we go to net 4, I (hatton) think we can get rid of this. .net 4 cl
 				output.Append (GetChars (acc, e));
 			}
 
-			acc = null;
+			acc = null!;
 			return output.ToString ();
 		}
 
-		public static byte [] UrlDecodeToBytes (byte [] bytes)
+        [return: NotNullIfNotNull("bytes")]
+		public static byte[]? UrlDecodeToBytes (byte []? bytes)
 		{
 			if (bytes == null)
 				return null;
@@ -304,12 +311,14 @@ Actually when we go to net 4, I (hatton) think we can get rid of this. .net 4 cl
 			return UrlDecodeToBytes (bytes, 0, bytes.Length);
 		}
 
-		public static byte [] UrlDecodeToBytes (string str)
+        [return: NotNullIfNotNull("str")]
+		public static byte[]? UrlDecodeToBytes (string? str)
 		{
 			return UrlDecodeToBytes (str, Encoding.UTF8);
 		}
 
-		public static byte [] UrlDecodeToBytes (string str, Encoding e)
+        [return: NotNullIfNotNull("str")]
+		public static byte[]? UrlDecodeToBytes (string? str, Encoding e)
 		{
 			if (str == null)
 				return null;
@@ -320,7 +329,8 @@ Actually when we go to net 4, I (hatton) think we can get rid of this. .net 4 cl
 			return UrlDecodeToBytes (e.GetBytes (str));
 		}
 
-		public static byte [] UrlDecodeToBytes (byte [] bytes, int offset, int count)
+        [return: NotNullIfNotNull("bytes")]
+		public static byte[]? UrlDecodeToBytes (byte []? bytes, int offset, int count)
 		{
 			if (bytes == null)
 				return null;
@@ -353,12 +363,14 @@ Actually when we go to net 4, I (hatton) think we can get rid of this. .net 4 cl
 			return result.ToArray ();
 		}
 
-		public static string UrlEncode(string str)
+        [return: NotNullIfNotNull("str")]
+		public static string? UrlEncode(string? str)
 		{
 			return UrlEncode(str, Encoding.UTF8);
 		}
 
-		public static string UrlEncode (string s, Encoding Enc)
+        [return: NotNullIfNotNull("s")]
+		public static string? UrlEncode (string? s, Encoding Enc)
 		{
 			if (s == null)
 				return null;
@@ -388,7 +400,8 @@ Actually when we go to net 4, I (hatton) think we can get rid of this. .net 4 cl
 			return Encoding.ASCII.GetString (UrlEncodeToBytes (bytes, 0, realLen));
 		}
 
-		public static string UrlEncode (byte [] bytes)
+        [return: NotNullIfNotNull("bytes")]
+		public static string? UrlEncode (byte []? bytes)
 		{
 			if (bytes == null)
 				return null;
@@ -399,7 +412,8 @@ Actually when we go to net 4, I (hatton) think we can get rid of this. .net 4 cl
 			return Encoding.ASCII.GetString (UrlEncodeToBytes (bytes, 0, bytes.Length));
 		}
 
-		public static string UrlEncode (byte [] bytes, int offset, int count)
+        [return: NotNullIfNotNull("bytes")]
+		public static string? UrlEncode (byte []? bytes, int offset, int count)
 		{
 			if (bytes == null)
 				return null;
@@ -410,12 +424,14 @@ Actually when we go to net 4, I (hatton) think we can get rid of this. .net 4 cl
 			return Encoding.ASCII.GetString (UrlEncodeToBytes (bytes, offset, count));
 		}
 
-		public static byte [] UrlEncodeToBytes (string str)
+        [return: NotNullIfNotNull("str")]
+		public static byte[]? UrlEncodeToBytes (string? str)
 		{
 			return UrlEncodeToBytes (str, Encoding.UTF8);
 		}
 
-		public static byte [] UrlEncodeToBytes (string str, Encoding e)
+		[return: NotNullIfNotNull("str")]
+		public static byte[]? UrlEncodeToBytes (string? str, Encoding e)
 		{
 			if (str == null)
 				return null;
@@ -427,7 +443,8 @@ Actually when we go to net 4, I (hatton) think we can get rid of this. .net 4 cl
 			return UrlEncodeToBytes (bytes, 0, bytes.Length);
 		}
 
-		public static byte [] UrlEncodeToBytes (byte [] bytes)
+		[return: NotNullIfNotNull("bytes")]
+		public static byte[]? UrlEncodeToBytes (byte []? bytes)
 		{
 			if (bytes == null)
 				return null;
@@ -438,7 +455,8 @@ Actually when we go to net 4, I (hatton) think we can get rid of this. .net 4 cl
 			return UrlEncodeToBytes (bytes, 0, bytes.Length);
 		}
 
-		public static byte [] UrlEncodeToBytes (byte [] bytes, int offset, int count)
+		[return: NotNullIfNotNull("bytes")]
+		public static byte[]? UrlEncodeToBytes (byte []? bytes, int offset, int count)
 		{
 			if (bytes == null)
 				return null;
@@ -449,7 +467,8 @@ Actually when we go to net 4, I (hatton) think we can get rid of this. .net 4 cl
 #endif
 		}
 
-		public static string UrlEncodeUnicode (string str)
+		[return: NotNullIfNotNull("str")]
+		public static string? UrlEncodeUnicode (string? str)
 		{
 			if (str == null)
 				return null;
@@ -457,7 +476,8 @@ Actually when we go to net 4, I (hatton) think we can get rid of this. .net 4 cl
 			return Encoding.ASCII.GetString (UrlEncodeUnicodeToBytes (str));
 		}
 
-		public static byte [] UrlEncodeUnicodeToBytes (string str)
+		[return: NotNullIfNotNull("str")]
+		public static byte[]? UrlEncodeUnicodeToBytes (string? str)
 		{
 			if (str == null)
 				return null;
@@ -477,7 +497,8 @@ Actually when we go to net 4, I (hatton) think we can get rid of this. .net 4 cl
 		/// </summary>
 		/// <param name="s">The HTML string to decode. </param>
 		/// <returns>The decoded text.</returns>
-		public static string HtmlDecode (string s)
+		[return: NotNullIfNotNull("s")]
+		public static string? HtmlDecode (string? s)
 		{
 #if NET_4_0
 			if (s == null)
@@ -516,7 +537,8 @@ Actually when we go to net 4, I (hatton) think we can get rid of this. .net 4 cl
 			}
 		}
 
-		public static string HtmlEncode (string s)
+		[return: NotNullIfNotNull("s")]
+		public static string? HtmlEncode (string? s)
 		{
 #if NET_4_0
 			if (s == null)
@@ -697,7 +719,7 @@ Actually when we go to net 4, I (hatton) think we can get rid of this. .net 4 cl
 						namePos++;
 				}
 
-				string name, value;
+				string? name, value;
 				if (valuePos == -1) {
 					name = null;
 					valuePos = namePos;

--- a/src/L10NSharp/Utils.cs
+++ b/src/L10NSharp/Utils.cs
@@ -48,7 +48,7 @@ namespace L10NSharp
 		/// the method exists you should check first with HasProperty.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public static object GetProperty(object binding, string propertyName)
+		public static object? GetProperty(object binding, string propertyName)
 		{
 			// It's not clear why this is needed. There is some indication (http://stackoverflow.com/questions/3546580/why-is-it-not-possible-to-catch-missingmethodexception)
 			// that MissingMethodException cannot be caught. In one situation in Bloom, with a ToolStripButton (which does not implement ShortcutKeys),

--- a/src/L10NSharp/XLiffUtils/XLiffBaseWithNotesAndProps.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffBaseWithNotesAndProps.cs
@@ -45,7 +45,7 @@ namespace L10NSharp.XLiffUtils
 		/// Adds a note to the notes list.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public bool AddNote(string lang, string text)
+		public bool AddNote(string? lang, string text)
 		{
 			return XLiffNote.AddNote(lang, text, _notes);
 		}
@@ -120,7 +120,7 @@ namespace L10NSharp.XLiffUtils
 		/// specified type doesn't exist, then null is returned.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public string GetPropValue(string type)
+		public string? GetPropValue(string type)
 		{
 			return _props.Where(p => p.Type == type).Select(p => p.Value).FirstOrDefault();
 		}
@@ -130,7 +130,7 @@ namespace L10NSharp.XLiffUtils
 		/// Check whether the give comment already exists as a note.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public bool NotesContain(string comment)
+		public bool NotesContain(string? comment)
 		{
 			return _notes.Any(n => n.Text == comment);
 		}
@@ -142,9 +142,9 @@ namespace L10NSharp.XLiffUtils
 		/// "comment" if it exists.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public string GetComment()
+		public string? GetComment()
 		{
-			var commentNote = _notes.FirstOrDefault(n => !string.IsNullOrEmpty(n.Text) && !n.Text.StartsWith("ID: "));
+			var commentNote = _notes.FirstOrDefault(n => !string.IsNullOrEmpty(n.Text) && !n.Text!.StartsWith("ID: "));
 			return commentNote?.Text;
 		}
 	}

--- a/src/L10NSharp/XLiffUtils/XLiffBody.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffBody.cs
@@ -241,12 +241,12 @@ namespace L10NSharp.XLiffUtils
 							if (string.IsNullOrWhiteSpace(tu.Target?.Value))
 								continue;
 							if (tu.TranslationStatus == TranslationStatus.Approved ||
-							    tu.Target.TargetState == XLiffTransUnitVariant.TranslationState.Translated)
+							    tu.Target!.TargetState == XLiffTransUnitVariant.TranslationState.Translated)
 							{
 								++_translatedCount;
 							}
 							else if (!string.IsNullOrWhiteSpace(tu.Source?.Value) &&
-							         tu.Target.Value != tu.Source.Value &&
+							         tu.Target.Value != tu.Source?.Value &&
 							         tu.Target.TargetState == XLiffTransUnitVariant.TranslationState.Undefined)
 							{
 								++_translatedCount;

--- a/src/L10NSharp/XLiffUtils/XLiffBody.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffBody.cs
@@ -91,16 +91,18 @@ namespace L10NSharp.XLiffUtils
 		/// Gets the translation unit for the specified id.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		internal XLiffTransUnit GetTransUnitForId(string id)
+		internal XLiffTransUnit? GetTransUnitForId(string? id)
 		{
-			_transUnitDict.TryGetValue(id, out XLiffTransUnit result);
+            if (id == null)
+                return null;
+			_transUnitDict.TryGetValue(id, out XLiffTransUnit? result);
 			return result;
 		}
 
 		/// <summary>
 		/// When all but the last part of the id changed, this can help reunite things
 		/// </summary>
-		internal XLiffTransUnit GetTransUnitForOrphan(XLiffTransUnit orphan, XLiffBody source)
+		internal XLiffTransUnit? GetTransUnitForOrphan(XLiffTransUnit orphan, XLiffBody? source)
 		{
 			var terminalIdToMatch = XliffLocalizedStringCache.GetTerminalIdPart(orphan.Id);
 			var defaultTextToMatch = GetDefaultVariantValue(orphan);
@@ -111,7 +113,7 @@ namespace L10NSharp.XLiffUtils
 				&& source?.GetTransUnitForId(tu.Id) == null); // and translation does not already have an element for this
 		}
 
-		string GetDefaultVariantValue(XLiffTransUnit tu)
+		string? GetDefaultVariantValue(XLiffTransUnit tu)
 		{
 			var variant = tu.GetVariantForLang(LocalizationManager.kDefaultLang);
 			return variant?.Value;
@@ -124,7 +126,7 @@ namespace L10NSharp.XLiffUtils
 		/// <param name="tu">The translation unit.</param>
 		/// <returns>true if the translation unit was successfully added. Otherwise, false.</returns>
 		/// ------------------------------------------------------------------------------------
-		internal bool AddTransUnitRaw(XLiffTransUnit tu)
+		internal bool AddTransUnitRaw(XLiffTransUnit? tu)
 		{
 			if (tu == null || tu.IsEmpty)
 				return false;
@@ -189,6 +191,8 @@ namespace L10NSharp.XLiffUtils
 				return;
 
 			var existingTu = GetTransUnitForId(tu.Id);
+			if (existingTu == null)
+				return;
 
 			//notice, we don't care if there is already a string in there for this language
 			//(that was the cause of a previous bug), because the XLiff of language X should

--- a/src/L10NSharp/XLiffUtils/XLiffDocument.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffDocument.cs
@@ -59,7 +59,7 @@ namespace L10NSharp.XLiffUtils
 		/// Gets the translation unit for the specified id.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public XLiffTransUnit GetTransUnitForId(string id)
+		public XLiffTransUnit? GetTransUnitForId(string id)
 		{
 			return File.Body.GetTransUnitForId(id);
 		}
@@ -82,7 +82,9 @@ namespace L10NSharp.XLiffUtils
 		/// ------------------------------------------------------------------------------------
 		public bool AddTransUnit(ITransUnit tu)
 		{
-			return File.Body.AddTransUnit(tu as XLiffTransUnit);
+			if (tu is not XLiffTransUnit xliffTu)
+				return false;
+			return File.Body.AddTransUnit(xliffTu);
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -90,9 +92,10 @@ namespace L10NSharp.XLiffUtils
 		/// Remove the specified translation unit.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public void RemoveTransUnit(ITransUnit tu)
+		public void RemoveTransUnit(ITransUnit? tu)
 		{
-			File.Body.RemoveTransUnit(tu as XLiffTransUnit);
+			if (tu is XLiffTransUnit xliffTu)
+				File.Body.RemoveTransUnit(xliffTu);
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -136,12 +139,14 @@ namespace L10NSharp.XLiffUtils
 			if (!System.IO.File.Exists(xLiffFile))
 				throw new FileNotFoundException("XLiff file not found.", xLiffFile);
 
-			Exception e;
+			Exception? e;
 			var xLiffDoc =
 				XliffXmlSerializationHelper.DeserializeFromFile<XLiffDocument>(xLiffFile, out e);
 
 			if (e != null)
 				throw e;
+			if (xLiffDoc == null)
+				throw new InvalidOperationException("XLiff file could not be deserialized.", e);
 
 			// Fill in the fast lookup dictionary.
 			var langId = xLiffDoc.File.TargetLang;
@@ -149,7 +154,7 @@ namespace L10NSharp.XLiffUtils
 				langId = xLiffDoc.File.SourceLang;
 			foreach (var tu in xLiffDoc.File.Body.TransUnitsUnordered)
 			{
-				if (xLiffDoc.File.Body.TranslationsById.ContainsKey(tu.Id))
+				if (xLiffDoc.File.Body.TranslationsById.ContainsKey(tu.Id!))
 				{
 					Console.WriteLine("WARNING: string ID \"{0}\" already found in \"{1}\".",
 						tu.Id, xLiffFile);
@@ -159,9 +164,9 @@ namespace L10NSharp.XLiffUtils
 						!LocalizationManager.ReturnOnlyApprovedStrings ||
 						(tu.TranslationStatus == TranslationStatus.Approved))
 				{
-					var target = tu.GetVariantForLang(langId);
+					var target = tu.GetVariantForLang(langId!);
 					if (target != null && !string.IsNullOrEmpty(target.Value))
-						xLiffDoc.File.Body.TranslationsById[tu.Id] = target.Value;
+						xLiffDoc.File.Body.TranslationsById[tu.Id!] = target.Value;
 				}
 			}
 
@@ -178,7 +183,7 @@ namespace L10NSharp.XLiffUtils
 		/// has an ID matching something in that. (This argument should always be supplied, but
 		/// for backwards compatibility we allow it to be omitted.)
 		/// </summary>
-		public XLiffTransUnit GetTransUnitForOrphan(XLiffTransUnit orphan, XLiffBody source = null)
+		public XLiffTransUnit? GetTransUnitForOrphan(XLiffTransUnit orphan, XLiffBody? source = null)
 		{
 			return File.Body.GetTransUnitForOrphan(orphan, source);
 		}

--- a/src/L10NSharp/XLiffUtils/XLiffFile.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffFile.cs
@@ -21,7 +21,7 @@ namespace L10NSharp.XLiffUtils
 			DataType = "plaintext";
 		}
 
-		protected XLiffHeader _header /* = new XLiffHeader()*/;
+		protected XLiffHeader? _header /* = new XLiffHeader()*/;
 		protected XLiffBody   _body = new XLiffBody();
 
 		#region Properties
@@ -32,7 +32,7 @@ namespace L10NSharp.XLiffUtils
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[XmlElement("header")]
-		public XLiffHeader Header
+		public XLiffHeader? Header
 		{
 			get => _header;
 			set => _header = value;
@@ -65,7 +65,7 @@ namespace L10NSharp.XLiffUtils
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[XmlAttribute("target-language")]
-		public string TargetLang { get; set; }
+		public string? TargetLang { get; set; }
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -81,7 +81,7 @@ namespace L10NSharp.XLiffUtils
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[XmlAttribute("original")]
-		public string Original { get; set; }
+		public string? Original { get; set; }
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -101,7 +101,7 @@ namespace L10NSharp.XLiffUtils
 		[XmlAttribute("hard-linebreak-replacement", Namespace =
 			XliffXmlSerializationHelper.kSilNamespace),
 		DefaultValue(LocalizedStringCache.kDefaultNewlineReplacement)]
-		public string HardLineBreakReplacement { get; set; }
+		public string? HardLineBreakReplacement { get; set; }
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -113,7 +113,7 @@ namespace L10NSharp.XLiffUtils
 		[XmlAttribute("ampersand-replacement", Namespace =
 			XliffXmlSerializationHelper.kSilNamespace),
 		DefaultValue(LocalizedStringCache.kDefaultAmpersandReplacement)]
-		public string AmpersandReplacement { get; set; }
+		public string? AmpersandReplacement { get; set; }
 
 		#endregion
 	}

--- a/src/L10NSharp/XLiffUtils/XLiffNote.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffNote.cs
@@ -17,7 +17,7 @@ namespace L10NSharp.XLiffUtils
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[XmlAttribute("xml:lang")]
-		public string NoteLang { get; set; }
+		public string? NoteLang { get; set; }
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -25,7 +25,7 @@ namespace L10NSharp.XLiffUtils
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[XmlAttribute("from")]
-		public string From { get; set; }
+		public string? From { get; set; }
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -41,7 +41,7 @@ namespace L10NSharp.XLiffUtils
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[XmlAttribute("annotates")]
-		public string Annotates { get; set; }
+		public string? Annotates { get; set; }
 
 
 
@@ -51,7 +51,7 @@ namespace L10NSharp.XLiffUtils
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[XmlText]
-		public string Text { get; set; }
+		public string? Text { get; set; }
 
 		#endregion
 
@@ -104,7 +104,7 @@ namespace L10NSharp.XLiffUtils
 		/// Adds the note.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public static bool AddNote(string lang, string text, List<XLiffNote> noteList)
+		public static bool AddNote(string? lang, string text, List<XLiffNote> noteList)
 		{
 			var note = new XLiffNote();
 			note.Text = text;

--- a/src/L10NSharp/XLiffUtils/XLiffProp.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffProp.cs
@@ -21,7 +21,7 @@ namespace L10NSharp.XLiffUtils
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[XmlAttribute("type")]
-		public string Type { get; set; }
+		public string? Type { get; set; }
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -29,7 +29,7 @@ namespace L10NSharp.XLiffUtils
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[XmlAttribute("xml:lang")]
-		public string Lang { get; set; }
+		public string? Lang { get; set; }
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -37,7 +37,7 @@ namespace L10NSharp.XLiffUtils
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[XmlText]
-		public string Value { get; set; }
+		public string? Value { get; set; }
 
 		#endregion
 
@@ -82,7 +82,7 @@ namespace L10NSharp.XLiffUtils
 		/// Adds a property.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		internal static bool AddProp(string lang, string type, string value, List<XLiffProp> propList)
+		internal static bool AddProp(string? lang, string type, string value, List<XLiffProp> propList)
 		{
 			var prop = new XLiffProp();
 			prop.Lang = lang;

--- a/src/L10NSharp/XLiffUtils/XLiffTargetVariant.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffTargetVariant.cs
@@ -16,7 +16,7 @@ namespace L10NSharp.XLiffUtils
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[XmlAttribute("xml:lang")]
-		public string Lang { get; set; }
+		public string? Lang { get; set; }
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -24,7 +24,7 @@ namespace L10NSharp.XLiffUtils
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[XmlText]
-		public string Value { get; set; }
+		public string? Value { get; set; }
 
 		#endregion
 	}

--- a/src/L10NSharp/XLiffUtils/XLiffTransUnit.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffTransUnit.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Xml.Serialization;
 using static System.String;
 
@@ -24,7 +25,7 @@ namespace L10NSharp.XLiffUtils
 
 		/// ------------------------------------------------------------------------------------
 		[XmlAttribute("id")]
-		public string Id { get; set; }
+		public string? Id { get; set; }
 
 		//  approved="yes"
 
@@ -59,7 +60,7 @@ namespace L10NSharp.XLiffUtils
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[XmlElement("target")]
-		public XLiffTransUnitVariant Target { get; set; }
+		public XLiffTransUnitVariant? Target { get; set; }
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -83,7 +84,7 @@ namespace L10NSharp.XLiffUtils
 		/// <remarks>This appears to not be used in the Bloom files.</remarks>
 		/// ------------------------------------------------------------------------------------
 		[XmlAttribute("priority", Namespace = XliffXmlSerializationHelper.kSilNamespace)]
-		public string Priority { get; set; }
+		public string? Priority { get; set; }
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -93,7 +94,7 @@ namespace L10NSharp.XLiffUtils
 		/// <remarks>This appears to not be used in the Bloom files.</remarks>
 		/// ------------------------------------------------------------------------------------
 		[XmlAttribute("group", Namespace = XliffXmlSerializationHelper.kSilNamespace)]
-		public string Group { get; set; }
+		public string? Group { get; set; }
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -105,7 +106,7 @@ namespace L10NSharp.XLiffUtils
 		/// <remarks>This appears to not be used in the Bloom files.</remarks>
 		/// ------------------------------------------------------------------------------------
 		[XmlAttribute("category", Namespace = XliffXmlSerializationHelper.kSilNamespace)]
-		public string Category { get; set; }
+		public string? Category { get; set; }
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -113,6 +114,7 @@ namespace L10NSharp.XLiffUtils
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[XmlIgnore]
+        [MemberNotNullWhen(false, nameof(Id), nameof(Source), nameof(Target))]
 		public bool IsEmpty =>
 			IsNullOrEmpty(Id) && Notes.Count == 0 && Source == null && Target == null;
 
@@ -143,7 +145,7 @@ namespace L10NSharp.XLiffUtils
 		/// <param name="tuv">The variant.</param>
 		/// <returns>true if the variant was successfully added. Otherwise, false.</returns>
 		/// ------------------------------------------------------------------------------------
-		public bool AddOrReplaceVariant(XLiffTransUnitVariant tuv)
+		public bool AddOrReplaceVariant(XLiffTransUnitVariant? tuv)
 		{
 			if (tuv == null)
 				return false;
@@ -173,9 +175,9 @@ namespace L10NSharp.XLiffUtils
 		/// Removes the variant for the specified language.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public void RemoveVariant(string langId)
+		public void RemoveVariant(string? langId)
 		{
-			XLiffTransUnitVariant tuv = GetVariantForLang(langId);
+			XLiffTransUnitVariant? tuv = GetVariantForLang(langId);
 			if (tuv != null)
 			{
 				if (langId == kDefaultLangId)
@@ -190,7 +192,7 @@ namespace L10NSharp.XLiffUtils
 		/// Gets the translation unit variant for the specified language id.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public XLiffTransUnitVariant GetVariantForLang(string langId)
+		public XLiffTransUnitVariant? GetVariantForLang(string? langId)
 		{
 			if (langId == kDefaultLangId)
 				return Source;

--- a/src/L10NSharp/XLiffUtils/XLiffTransUnitVariant.cs
+++ b/src/L10NSharp/XLiffUtils/XLiffTransUnitVariant.cs
@@ -21,7 +21,7 @@ namespace L10NSharp.XLiffUtils
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[XmlAttribute("xml:lang")]
-		public string Lang { get; set; }
+		public string? Lang { get; set; }
 
 		// Crowdin uses only "needs-translated" and "translated" as far as I can tell.  It appears to remove
 		// this attribute ("undefined") and use the "approved" attribute on the trans-unit element to
@@ -81,7 +81,7 @@ namespace L10NSharp.XLiffUtils
 		[XmlAttribute("state"), System.ComponentModel.DefaultValue(TranslationState.Undefined)]
 		public TranslationState TargetState;
 
-		private string _value;
+		private string? _value;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -110,7 +110,7 @@ namespace L10NSharp.XLiffUtils
 					_deserializedFromElement = null;
 				}
 
-				return _value;
+				return _value ?? string.Empty;
 			}
 			set => _value = value;
 		}
@@ -119,7 +119,7 @@ namespace L10NSharp.XLiffUtils
 		/// This is a temp value that allows complex input strings (with xliff-style html markup)
 		/// to be deserialized properly.
 		/// </summary>
-		private string _deserializedFromElement;
+		private string? _deserializedFromElement;
 
 		/// <summary>
 		/// Save the value deserialized from an element (and anything preceding it), and clear

--- a/src/L10NSharp/XLiffUtils/XliffLocalizationManager.cs
+++ b/src/L10NSharp/XLiffUtils/XliffLocalizationManager.cs
@@ -639,7 +639,7 @@ namespace L10NSharp.XLiffUtils
 							++changedStringCount;
 							changedStringIds.Add(tu.Id!);
 							if (!string.IsNullOrWhiteSpace(tuOld.Source?.Value))
-								tu.AddNote("en", $"OLD TEXT (before {xliffNew.File.ProductVersion}): {tuOld.Source.Value}");
+								tu.AddNote("en", $"OLD TEXT (before {xliffNew.File.ProductVersion}): {tuOld.Source!.Value}");
 						}
 						if (tuOld.Dynamic && !tu.Dynamic)
 						{

--- a/src/L10NSharp/XLiffUtils/XliffLocalizationManager.cs
+++ b/src/L10NSharp/XLiffUtils/XliffLocalizationManager.cs
@@ -13,17 +13,17 @@ namespace L10NSharp.XLiffUtils
 	/// ----------------------------------------------------------------------------------------
 	internal class XliffLocalizationManager : ILocalizationManagerInternal<XLiffDocument>
 	{
-		public event EventHandler UiLanguageChanged;
+		public event EventHandler? UiLanguageChanged;
 
 		/// ------------------------------------------------------------------------------------
 		public const string FileExtension = ".xlf";
-		private readonly string _installedXliffFileFolder;
-		private readonly string _generatedDefaultXliffFileFolder;
-		private readonly string _customXliffFileFolder;
-		private readonly string _origExeExtension;
+		private readonly string? _installedXliffFileFolder;
+		private readonly string? _generatedDefaultXliffFileFolder;
+		private readonly string? _customXliffFileFolder;
+		private readonly string? _origExeExtension;
 		private readonly Version _appVersion;
 
-		public Dictionary<IComponent, string> ComponentCache { get; }
+		public Dictionary<IComponent, string> ComponentCache { get; } = new Dictionary<IComponent, string>();
 
 		#region Static methods
 		/// ------------------------------------------------------------------------------------
@@ -82,7 +82,7 @@ namespace L10NSharp.XLiffUtils
 		internal XliffLocalizationManager(string appId, string origExtension, string appName,
 			string appVersion, string directoryOfInstalledXliffFiles,
 			string directoryForGeneratedDefaultXliffFile, string directoryOfUserModifiedXliffFiles,
-			IEnumerable<MethodInfo> additionalLocalizationMethods,
+			IEnumerable<MethodInfo>? additionalLocalizationMethods,
 			params string[] namespaceBeginnings) : this(appId, appName ?? appId, appVersion)
 		{
 			// Test for a pathological case of bad install
@@ -94,7 +94,7 @@ namespace L10NSharp.XLiffUtils
 			_installedXliffFileFolder = directoryOfInstalledXliffFiles;
 			_generatedDefaultXliffFileFolder = directoryForGeneratedDefaultXliffFile;
 			DefaultStringFilePath = GetPathForLanguage(LocalizationManager.kDefaultLang,
-				false);
+				false) ?? throw new InvalidOperationException($"Default file path is null for language {LocalizationManager.kDefaultLang}");
 
 			CollectUpNewStringsDiscoveredDynamically = true;
 
@@ -104,7 +104,6 @@ namespace L10NSharp.XLiffUtils
 			if (string.IsNullOrEmpty(_customXliffFileFolder))
 				_customXliffFileFolder = null;
 
-			ComponentCache = new Dictionary<IComponent, string>();
 			StringCache = new XliffLocalizedStringCache(this);
 		}
 
@@ -144,7 +143,7 @@ namespace L10NSharp.XLiffUtils
 
 		/// ------------------------------------------------------------------------------------
 		private void CreateOrUpdateDefaultXliffFileIfNecessary(
-			IEnumerable<MethodInfo> additionalLocalizationMethods,
+			IEnumerable<MethodInfo>? additionalLocalizationMethods,
 			params string[] namespaceBeginnings)
 		{
 			// Make sure the folder exists.
@@ -152,7 +151,7 @@ namespace L10NSharp.XLiffUtils
 			if (dir != null && !Directory.Exists(dir))
 				Directory.CreateDirectory(dir);
 
-			var defaultStringFileInstalledPath = Path.Combine(_installedXliffFileFolder,
+			var defaultStringFileInstalledPath = Path.Combine(_installedXliffFileFolder ?? throw new InvalidOperationException($"Installed file path is null"),
 				GetXliffFileNameForLanguage(LocalizationManager.kDefaultLang));
 
 			if (ScanningForCurrentStrings && DefaultStringFileExistsAndHasContents())
@@ -163,7 +162,7 @@ namespace L10NSharp.XLiffUtils
 
 			if (DefaultStringFileExistsAndHasContents())
 			{
-				XAttribute verAttribute = null;
+				XAttribute? verAttribute = null;
 				try
 				{
 					var xmlDoc = XElement.Load(DefaultStringFilePath);
@@ -217,8 +216,8 @@ namespace L10NSharp.XLiffUtils
 
 		public static List<string> ExtractionExceptions = new List<string>();
 
-		public static IReadOnlyList<LocalizingInfo> ExtractStringsFromCode(string name,
-			IEnumerable<MethodInfo> additionalLocalizationMethods, string[] namespaceBeginnings)
+		public static IReadOnlyList<LocalizingInfo>? ExtractStringsFromCode(string name,
+			IEnumerable<MethodInfo>? additionalLocalizationMethods, string[] namespaceBeginnings)
 		{
 			try
 			{
@@ -275,7 +274,7 @@ namespace L10NSharp.XLiffUtils
 		/// set of localized strings.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public string OriginalExecutableFile => Id + _origExeExtension;
+		public string OriginalExecutableFile => Id + (_origExeExtension ?? string.Empty);
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -308,7 +307,7 @@ namespace L10NSharp.XLiffUtils
 					LocalizationManager.kDefaultLang));
 
 		/// ------------------------------------------------------------------------------------
-		public ILocalizedStringCache<XLiffDocument> StringCache { get; }
+		public ILocalizedStringCache<XLiffDocument> StringCache { get; } = null!;
 
 
 		/// ------------------------------------------------------------------------------------
@@ -327,7 +326,7 @@ namespace L10NSharp.XLiffUtils
 			get
 			{
 				HashSet<string> langIdsOfCustomizedLocales = new HashSet<string>();
-				string langId;
+				string? langId;
 				if (_customXliffFileFolder != null && Directory.Exists(_customXliffFileFolder))
 				{
 					if (LocalizationManager.UseLanguageCodeFolders)
@@ -339,7 +338,7 @@ namespace L10NSharp.XLiffUtils
 							if (string.IsNullOrEmpty(langId) || langId == LocalizationManager.kDefaultLang)
 								continue;
 
-							langIdsOfCustomizedLocales.Add(langId);
+							langIdsOfCustomizedLocales.Add(langId!);
 							yield return xliffFile;
 						}
 					}
@@ -349,10 +348,10 @@ namespace L10NSharp.XLiffUtils
 							$"{Id}.*{FileExtension}"))
 						{
 							langId = GetLangIdFromXliffFileName(xliffFile);
-							if (langId == LocalizationManager.kDefaultLang)
+							if (string.IsNullOrEmpty(langId) || langId == LocalizationManager.kDefaultLang)
 								continue;
 
-							langIdsOfCustomizedLocales.Add(langId);
+							langIdsOfCustomizedLocales.Add(langId!);
 							yield return xliffFile;
 						}
 					}
@@ -368,9 +367,9 @@ namespace L10NSharp.XLiffUtils
 							if (string.IsNullOrEmpty(langId) || langId == LocalizationManager.kDefaultLang)
 								continue;
 
-							if (!langIdsOfCustomizedLocales.Contains(langId))
+							if (!langIdsOfCustomizedLocales.Contains(langId!))
 							{
-								langIdsOfCustomizedLocales.Add(langId);
+								langIdsOfCustomizedLocales.Add(langId!);
 								yield return xliffFile;
 							}
 						}
@@ -381,9 +380,14 @@ namespace L10NSharp.XLiffUtils
 							$"{Id}.*{FileExtension}"))
 						{
 							langId = GetLangIdFromXliffFileName(xliffFile);
-							if (langId != LocalizationManager.kDefaultLang &&    //Don't return the english Xliff here because we separately process it first.
-								!langIdsOfCustomizedLocales.Contains(langId))
+							if (string.IsNullOrEmpty(langId) || langId == LocalizationManager.kDefaultLang)
+								continue;
+
+							if (!langIdsOfCustomizedLocales.Contains(langId!))
+							{
+								langIdsOfCustomizedLocales.Add(langId!);
 								yield return xliffFile;
+							}
 						}
 					}
 				}
@@ -393,7 +397,7 @@ namespace L10NSharp.XLiffUtils
 
 		#region Methods for caching and localizing objects.
 		/// ------------------------------------------------------------------------------------
-		public void SaveIfDirty(ICollection<string> langIdsToForceCreate)
+		public void SaveIfDirty(ICollection<string>? langIdsToForceCreate)
 		{
 			try
 			{
@@ -407,7 +411,7 @@ namespace L10NSharp.XLiffUtils
 		}
 
 		/// ------------------------------------------------------------------------------------
-		internal static string GetLangIdFromXliffFileName(string fileName)
+		internal static string? GetLangIdFromXliffFileName(string fileName)
 		{
 			if (LocalizationManager.UseLanguageCodeFolders)
 			{
@@ -426,11 +430,11 @@ namespace L10NSharp.XLiffUtils
 		}
 
 		/// ------------------------------------------------------------------------------------
-		public string GetPathForLanguage(string langId, bool getCustomPathEvenIfNonexistent)
+		public string? GetPathForLanguage(string langId, bool getCustomPathEvenIfNonexistent)
 		{
 			var filename = GetXliffFileNameForLanguage(langId);
 			if (langId == LocalizationManager.kDefaultLang)
-				return Path.Combine(_generatedDefaultXliffFileFolder, filename);
+				return Path.Combine(_generatedDefaultXliffFileFolder ?? throw new InvalidOperationException($"Generated default file path is null for language {langId}"), filename);
 			if (_customXliffFileFolder != null)
 			{
 				var customXliffFile = Path.Combine(_customXliffFileFolder, filename);
@@ -487,22 +491,22 @@ namespace L10NSharp.XLiffUtils
 		/// Gets the localized text for the specified id.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public string GetLocalizedString(string id, string defaultText)
+		public string GetLocalizedString(string id, string? defaultText)
 		{
 			var text = (UILanguageId != LocalizationManager.kDefaultLang ? GetStringFromStringCache(UILanguageId, id) : null);
 
-			return text ?? LocalizationManager.StripOffLocalizationInfoFromText(defaultText);
+			return text ?? LocalizationManager.StripOffLocalizationInfoFromText(defaultText) ?? string.Empty;
 		}
 
 		/// ------------------------------------------------------------------------------------
-		public string GetStringFromStringCache(string uiLangId, string id)
+		public string? GetStringFromStringCache(string uiLangId, string id)
 		{
 			var realLangId = LocalizationManagerInternal<XLiffDocument>.MapToExistingLanguageIfPossible(uiLangId);
 			return StringCache.GetString(realLangId, id);
 		}
 
 		/// ------------------------------------------------------------------------------------
-		protected string GetTooltipFromStringCache(string uiLangId, string id)
+		protected string? GetTooltipFromStringCache(string uiLangId, string id)
 		{
 			var realLangId = LocalizationManagerInternal<XLiffDocument>.MapToExistingLanguageIfPossible(uiLangId);
 			return StringCache.GetToolTipText(realLangId, id);
@@ -600,18 +604,18 @@ namespace L10NSharp.XLiffUtils
 					++newDynamicCount;
 				if (xliffOld != null)
 				{
-					var tuOld = xliffOld.File.Body.GetTransUnitForId(tu.Id);
+					var tuOld = xliffOld.File.Body.GetTransUnitForId(tu.Id!);
 					if (tuOld == null)
 					{
 						++newStringCount;
-						newStringIds.Add(tu.Id);
+						newStringIds.Add(tu.Id!);
 					}
 					else
 					{
 						foreach (var note in tuOld.Notes)
 						{
 							// Skip "Not found[...]" notes — the string IS found in this run.
-							if (note.Text.StartsWith("Not found"))
+							if (note.Text != null && note.Text.StartsWith("Not found"))
 								continue;
 							bool haveAlready = false;
 							foreach (var newNote in tu.Notes)
@@ -624,22 +628,22 @@ namespace L10NSharp.XLiffUtils
 							}
 							if (!haveAlready)
 							{
-								if (note.Text.StartsWith("[OLD NOTE]") || note.Text.StartsWith("OLD TEXT"))
+								if (note.Text != null && (note.Text.StartsWith("[OLD NOTE]") || note.Text.StartsWith("OLD TEXT")))
 									tu.AddNote(note.NoteLang, note.Text);
-								else
+								else if (note.Text != null)
 									tu.AddNote(note.NoteLang, "[OLD NOTE] " + note.Text);
 							}
 						}
 						if (tu.Source.Value != tuOld.Source.Value)
 						{
 							++changedStringCount;
-							changedStringIds.Add(tu.Id);
+							changedStringIds.Add(tu.Id!);
 							tu.AddNote("en", $"OLD TEXT (before {xliffNew.File.ProductVersion}): {tuOld.Source.Value}");
 						}
 						if (tuOld.Dynamic && !tu.Dynamic)
 						{
 							++wrongDynamicFlagCount;
-							wrongDynamicStringIds.Add(tu.Id);
+							wrongDynamicStringIds.Add(tu.Id!);
 							tu.AddNote("en", $"Not dynamic: found in static scan of compiled code (version {xliffNew.File.ProductVersion})");
 						}
 					}
@@ -652,25 +656,25 @@ namespace L10NSharp.XLiffUtils
 			{
 				foreach (var tu in xliffOld.File.Body.TransUnitsUnordered)
 				{
-					var tuNew = xliffNew.File.Body.GetTransUnitForId(tu.Id);
+					var tuNew = xliffNew.File.Body.GetTransUnitForId(tu.Id!);
 					if (tuNew == null)
 					{
 						xliffOutput.File.Body.AddTransUnit(tu);
 						if (tu.Dynamic)
 						{
 							++missingDynamicStringCount;
-							missingDynamicStringIds.Add(tu.Id);
+							missingDynamicStringIds.Add(tu.Id!);
 							if (newDynamicCount > 0) // note only if attempt made to collect dynamic strings
 							{
-								tu.Notes.RemoveAll(n => n.Text.StartsWith("Not found"));
+								tu.Notes.RemoveAll(n => n.Text != null && n.Text.StartsWith("Not found"));
 								tu.AddNote("en", $"Not found when running compiled program (version {xliffNew.File.ProductVersion})");
 							}
 						}
 						else
 						{
 							++missingStringCount;
-							missingStringIds.Add(tu.Id);
-							tu.Notes.RemoveAll(n => n.Text.StartsWith("Not found"));
+							missingStringIds.Add(tu.Id!);
+							tu.Notes.RemoveAll(n => n.Text != null && n.Text.StartsWith("Not found"));
 							tu.AddNote("en", $"Not found in static scan of compiled code (version {xliffNew.File.ProductVersion})");
 						}
 					}
@@ -745,7 +749,7 @@ namespace L10NSharp.XLiffUtils
 		/// If the given file exists, return its parent folder name as a language tag if it
 		/// appears to be valid (2 or 3 letters long or "zh-CN"). Otherwise, return <c>null</c>.
 		/// </summary>
-		private static string GetLanguageTagFromFilePath(string xliffFile)
+		private static string? GetLanguageTagFromFilePath(string xliffFile)
 		{
 			Debug.Assert(LocalizationManager.UseLanguageCodeFolders);
 			if (!File.Exists(xliffFile))

--- a/src/L10NSharp/XLiffUtils/XliffLocalizedStringCache.cs
+++ b/src/L10NSharp/XLiffUtils/XliffLocalizedStringCache.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Security;
@@ -51,6 +52,8 @@ namespace L10NSharp.XLiffUtils
 					Console.WriteLine("Error occurred reading localization file:");
 					Console.WriteLine(e.Message);
 					LocalizationManager.SetUILanguage(LocalizationManager.kDefaultLang);
+					if (DefaultXliffDocument is null)
+						throw new InvalidOperationException("DefaultXliffDocument could not be loaded", e);
 				}
 			}
 			else
@@ -72,13 +75,13 @@ namespace L10NSharp.XLiffUtils
 			IsDirty = false;
 		}
 
-		internal XLiffDocument GetDocument(string langId)
+		internal XLiffDocument? GetDocument(string langId)
 		{
-			TryGetDocument(langId, out XLiffDocument doc);
+			TryGetDocument(langId, out XLiffDocument? doc);
 			return doc;
 		}
 
-		public bool TryGetDocument(string langId, out XLiffDocument doc)
+		public bool TryGetDocument(string langId, [NotNullWhen(true)] out XLiffDocument? doc)
 		{
 			// It's tempting to try to do this with the ConcurrentDictionary method GetOrAdd.
 			// But it's not guaranteed that the doc which LoadXLiff loads will be put in
@@ -121,6 +124,7 @@ namespace L10NSharp.XLiffUtils
 		/// <summary>
 		/// May only be called from constructor. Not thread-safe.
 		/// </summary>
+		[MemberNotNull(nameof(DefaultXliffDocument))]
 		private void MergeXliffFilesIntoCache(IEnumerable<string> xliffFiles)
 		{
 			DefaultXliffDocument = XLiffDocument.Read(OwningManager.DefaultStringFilePath); // read the generated file
@@ -149,7 +153,7 @@ namespace L10NSharp.XLiffUtils
 				var langId = XliffLocalizationManager.GetLangIdFromXliffFileName(file);
 				Debug.Assert(!string.IsNullOrEmpty(langId));
 				Debug.Assert(langId != LocalizationManager.kDefaultLang);
-				_unloadedXliffDocuments[langId] = file;
+				_unloadedXliffDocuments[langId!] = file;
 			}
 		}
 
@@ -192,6 +196,8 @@ namespace L10NSharp.XLiffUtils
 
 			// This might be different, typically more specific, than the name we deduced from the file path.
 			var targetLang = xliffDoc.File.TargetLang;
+            if (targetLang is null)
+                throw new InvalidOperationException($"Target language not found in {file}");
 
 			// Now we have some maintenance to do on MapToExistingLanguage, which does not yet contain data
 			// about this file. It is definitely the one to use for targetLanguage.
@@ -227,6 +233,8 @@ namespace L10NSharp.XLiffUtils
 			var defunctUnits = new List<XLiffTransUnit>();
 			foreach (var tu in xliffDoc.File.Body.TransUnitsUnordered.ToList()) // need a list here because we may modify it while enumerating
 			{
+                if (tu.Id is null)
+                    throw new InvalidOperationException($"Translation unit ID is null in {file}");
 				// This block attempts to find 'orphans', that is, localizations that have been done using an obsolete ID.
 				// We assume the default language Xliff has only current IDs, and therefore don't look for orphans in that case.
 				// This guards against cases such as recently occurred in Bloom, where a dynamic ID EditTab.AddPageDialog.Title
@@ -251,7 +259,7 @@ namespace L10NSharp.XLiffUtils
 						if (xliffDoc.File.Body.TranslationsById.ContainsKey(tu.Id))
 						{
 							// adjust the document's internal cache
-							xliffDoc.File.Body.TranslationsById[movedUnit.Id] =
+							xliffDoc.File.Body.TranslationsById[movedUnit.Id!] =
 								xliffDoc.File.Body.TranslationsById[tu.Id];
 							xliffDoc.File.Body.TranslationsById.TryRemove(tu.Id, out _);
 						}
@@ -326,12 +334,12 @@ namespace L10NSharp.XLiffUtils
 		/// Otherwise, false is returned.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		internal void SaveIfDirty(ICollection<string> langIdsToForceCreate)
+		internal void SaveIfDirty(ICollection<string>? langIdsToForceCreate)
 		{
 			if (!IsDirty)
 				return;
 
-			StringBuilder errorMsg = null;
+			StringBuilder? errorMsg = null;
 			foreach (var langId in XliffDocuments.Keys)
 			{
 				try
@@ -381,8 +389,8 @@ namespace L10NSharp.XLiffUtils
 
 			foreach (var tu in DefaultXliffDocument.File.Body.TransUnitsUnordered)
 			{
-				var tuTarget = xliffOriginal.File.Body.GetTransUnitForId(tu.Id);
-				XLiffTransUnitVariant tuv = null;
+				var tuTarget = xliffOriginal.File.Body.GetTransUnitForId(tu.Id!);
+				XLiffTransUnitVariant? tuv = null;
 				if (tuTarget != null)
 					tuv = tuTarget.GetVariantForLang(langId);
 				// REVIEW: should we write units with no translation (target)?
@@ -393,7 +401,10 @@ namespace L10NSharp.XLiffUtils
 				newTu.Notes = tu.CopyNotes();
 				xliffOutput.AddTransUnit(newTu);
 			}
-			xliffOutput.Save(OwningManager.GetPathForLanguage(langId, true));
+			var outputPath = OwningManager.GetPathForLanguage(langId, true);
+			if (outputPath == null)
+                throw new InvalidOperationException($"Output path is null for language {langId}");
+			xliffOutput.Save(outputPath);
 		}
 		#endregion
 
@@ -402,7 +413,7 @@ namespace L10NSharp.XLiffUtils
 		/// Compares two translation units for equality.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		internal static int TuComparer(XLiffTransUnit tu1, XLiffTransUnit tu2)
+		internal static int TuComparer(XLiffTransUnit? tu1, XLiffTransUnit? tu2)
 		{
 			if (tu1 == null && tu2 == null)
 				return 0;
@@ -413,11 +424,11 @@ namespace L10NSharp.XLiffUtils
 			if (tu2 == null)
 				return 1;
 
-			string x = tu1.Group;
-			string y = tu2.Group;
+			string? x = tu1.Group;
+			string? y = tu2.Group;
 
 			if (x == y)
-				return string.CompareOrdinal(tu1.Id, tu2.Id);
+				return string.CompareOrdinal(tu1.Id ?? string.Empty, tu2.Id ?? string.Empty);
 
 			if (x == null)
 				return -1;
@@ -450,7 +461,7 @@ namespace L10NSharp.XLiffUtils
 		/// Gets the localized text for the specified id and suffix.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public string GetString(string langId, string id)
+		public string? GetString(string langId, string id)
 		{
 			return GetValueForLangAndIdWithFallback(langId, id);
 		}
@@ -462,7 +473,7 @@ namespace L10NSharp.XLiffUtils
 		/// is displayed nicely at runtime.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public string GetString(string langId, string id, bool formatForDisplay)
+		public string? GetString(string langId, string id, bool formatForDisplay)
 		{
 			return GetValueForExactLangAndId(langId, id, formatForDisplay);
 		}
@@ -472,7 +483,7 @@ namespace L10NSharp.XLiffUtils
 		/// Gets the localized tooltip text for the specified id and suffix.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public string GetToolTipText(string langId, string id)
+		public string? GetToolTipText(string langId, string id)
 		{
 			return GetValueForLangAndIdWithFallback(langId, id + kToolTipSuffix);
 		}
@@ -484,7 +495,7 @@ namespace L10NSharp.XLiffUtils
 		/// converted so the text is displayed nicely at runtime.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public string GetToolTipText(string langId, string id, bool formatForDisplay)
+		public string? GetToolTipText(string langId, string id, bool formatForDisplay)
 		{
 			return GetValueForExactLangAndId(langId, id + kToolTipSuffix, formatForDisplay);
 		}
@@ -494,7 +505,7 @@ namespace L10NSharp.XLiffUtils
 		/// Gets the localized tooltip text for the specified id and suffix.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public string GetShortcutKeysText(string langId, string id)
+		public string? GetShortcutKeysText(string langId, string id)
 		{
 			return GetValueForExactLangAndId(langId, id + kShortcutSuffix, false);
 		}
@@ -506,7 +517,7 @@ namespace L10NSharp.XLiffUtils
 		/// fails, then the default (i.e. "en") is used.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		protected string GetValueForLangAndIdWithFallback(string langId, string id)
+		protected string? GetValueForLangAndIdWithFallback(string langId, string id)
 		{
 			var value = GetValueForExactLangAndId(langId, id, true);
 			if (value != null)
@@ -529,7 +540,7 @@ namespace L10NSharp.XLiffUtils
 		/// nicely at runtime.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public string GetValueForExactLangAndId(string langId, string id, bool formatForDisplay)
+		public string? GetValueForExactLangAndId(string langId, string id, bool formatForDisplay)
 		{
 			if (string.IsNullOrEmpty(langId) || string.IsNullOrEmpty(id))
 				return null;
@@ -578,10 +589,9 @@ namespace L10NSharp.XLiffUtils
 		/// considered the "comment" if it exists.
 		/// </remarks>
 		/// ------------------------------------------------------------------------------------
-		public string GetComment(string id)
+		public string? GetComment(string id)
 		{
-			XLiffTransUnit tu = DefaultXliffDocument.GetTransUnitForId(id);
-			return (tu == null ? null : tu.GetComment());
+			return DefaultXliffDocument.GetTransUnitForId(id)?.GetComment();
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -589,10 +599,9 @@ namespace L10NSharp.XLiffUtils
 		/// Gets the group for the specified id.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		internal string GetGroup(string id)
+		internal string? GetGroup(string id)
 		{
-			XLiffTransUnit tu = DefaultXliffDocument.GetTransUnitForId(id);
-			return (tu == null ? null : tu.Group);
+			return DefaultXliffDocument.GetTransUnitForId(id)?.Group;
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -602,7 +611,7 @@ namespace L10NSharp.XLiffUtils
 		/// ------------------------------------------------------------------------------------
 		internal LocalizationPriority GetPriority(string id)
 		{
-			XLiffTransUnit tu = DefaultXliffDocument.GetTransUnitForId(id);
+			XLiffTransUnit? tu = DefaultXliffDocument.GetTransUnitForId(id);
 			if (tu != null)
 			{
 				if (string.IsNullOrEmpty(tu.Priority))
@@ -610,7 +619,7 @@ namespace L10NSharp.XLiffUtils
 
 				try
 				{
-					return (LocalizationPriority)Enum.Parse(typeof(LocalizationPriority), tu.Priority);
+					return (LocalizationPriority)Enum.Parse(typeof(LocalizationPriority), tu.Priority!);
 				}
 				catch { }
 			}
@@ -624,10 +633,10 @@ namespace L10NSharp.XLiffUtils
 		/// ------------------------------------------------------------------------------------
 		internal LocalizationCategory GetCategory(string id)
 		{
-			XLiffTransUnit tu = DefaultXliffDocument.GetTransUnitForId(id);
+			XLiffTransUnit? tu = DefaultXliffDocument.GetTransUnitForId(id);
 			if (tu != null)
 			{
-				string category = tu.Category;
+				string? category = tu.Category;
 				if (string.IsNullOrEmpty(category))
 					return LocalizationCategory.DontCare;
 
@@ -681,6 +690,8 @@ namespace L10NSharp.XLiffUtils
 		{
 			foreach (var tu in DefaultXliffDocument.File.Body.TransUnitsUnordered)
 			{
+                if (tu.Id is null)
+					throw new InvalidOperationException("Translation unit ID is null in DefaultXliffDocument");
 				// If the translation unit is not for a tooltip or shortcutkey, then return it.
 				if (!tu.Id.EndsWith(kToolTipSuffix) && !tu.Id.EndsWith(kShortcutSuffix))
 					yield return tu;
@@ -732,9 +743,11 @@ namespace L10NSharp.XLiffUtils
 			return allPieces;
 		}
 
-		public static string GetTerminalIdPart(string id)
+		public static string GetTerminalIdPart(string? id)
 		{
-			var pieces = id.Split('.');
+			if (string.IsNullOrEmpty(id))
+				return "";
+			var pieces = id!.Split('.');
 			if (pieces.Length == 0)
 				return "";
 			return pieces.Last();
@@ -752,7 +765,7 @@ namespace L10NSharp.XLiffUtils
 		{
 			try
 			{
-				string s = null;
+				string? s = null;
 				switch (markersCount)
 				{
 					case 0:

--- a/src/L10NSharp/XLiffUtils/XliffTransUnitUpdater.cs
+++ b/src/L10NSharp/XLiffUtils/XliffTransUnitUpdater.cs
@@ -27,7 +27,7 @@ namespace L10NSharp.XLiffUtils
 		{
 			_stringCache = cache;
 			_defaultLang = LocalizationManager.kDefaultLang;
-			var replacement = _stringCache.GetDocument(_defaultLang).File
+			var replacement = _stringCache.GetDocument(_defaultLang)?.File
 				.HardLineBreakReplacement;
 			if (replacement != null)
 				_literalNewline = replacement;
@@ -49,10 +49,10 @@ namespace L10NSharp.XLiffUtils
 			if (string.IsNullOrWhiteSpace(locInfo.Id))
 				return _updated;
 
-			var xliffSource = _stringCache.GetDocument(_defaultLang);
-			Debug.Assert(xliffSource != null);
+			if (!_stringCache.TryGetDocument(_defaultLang, out var xliffSource))
+                throw new InvalidOperationException($"Source document for default language {_defaultLang} not found");
 
-			if (!_stringCache.TryGetDocument(locInfo.LangId, out var xliffTarget))
+			if (!_stringCache.TryGetDocument(locInfo.LangId!, out var xliffTarget))
 			{
 				xliffTarget = new XLiffDocument();
 				xliffTarget.File.AmpersandReplacement = xliffSource.File.AmpersandReplacement;
@@ -65,10 +65,10 @@ namespace L10NSharp.XLiffUtils
 				xliffTarget.File.TargetLang = locInfo.LangId;
 				xliffTarget.IsDirty = true;
 				_updated = true;
-				_stringCache.AddDocument(locInfo.LangId, xliffTarget);
+				_stringCache.AddDocument(locInfo.LangId!, xliffTarget);
 			}
 
-			var tuSourceText = xliffSource.GetTransUnitForId(locInfo.Id);
+			var tuSourceText = xliffSource.GetTransUnitForId(locInfo.Id!);
 			var tuSourceToolTip = xliffSource.GetTransUnitForId(locInfo.Id + kToolTipSuffix);
 			var tuSourceShortcutKeys =
 				xliffSource.GetTransUnitForId(locInfo.Id + kShortcutSuffix);
@@ -116,7 +116,7 @@ namespace L10NSharp.XLiffUtils
 				text = text.Replace(_literalNewline, "@#$");
 				text = text.Replace(kOSRealNewline, _literalNewline);
 				text = text.Replace("@#$", _literalNewline);
-				UpdateValueAndComment(xliffTarget, tuSourceText, text, locInfo, locInfo.Id);
+				UpdateValueAndComment(xliffTarget, tuSourceText, text, locInfo, locInfo.Id!);
 			}
 
 			if (_updated)
@@ -124,15 +124,15 @@ namespace L10NSharp.XLiffUtils
 			return _updated;
 		}
 
-		void UpdateValueAndComment(XLiffDocument xliffTarget, XLiffTransUnit tuSource,
-			string                               newText,     LocalizingInfo locInfo, string tuId)
+		void UpdateValueAndComment(XLiffDocument xliffTarget, XLiffTransUnit? tuSource,
+			string?                               newText,     LocalizingInfo locInfo, string tuId)
 		{
 			var tuTarget = UpdateValue(xliffTarget, tuSource, newText, locInfo, tuId);
 			UpdateTransUnitComment(xliffTarget, tuSource, locInfo);
 			UpdateTransUnitComment(xliffTarget, tuTarget, locInfo);
 		}
 
-		private void UpdateTransUnitComment(XLiffDocument xliffTarget, XLiffTransUnit tu,
+		private void UpdateTransUnitComment(XLiffDocument xliffTarget, XLiffTransUnit? tu,
 			LocalizingInfo                                locInfo)
 		{
 			if (tu == null)
@@ -155,7 +155,7 @@ namespace L10NSharp.XLiffUtils
 			tu.Notes.Clear();
 			tu.AddNote("ID: " + tu.Id);
 			if (!string.IsNullOrEmpty(locInfo.Comment))
-				tu.AddNote(locInfo.Comment);
+				tu.AddNote(locInfo.Comment!);
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -163,8 +163,8 @@ namespace L10NSharp.XLiffUtils
 		/// Updates the value for the specified translation unit with the specified new value.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		private XLiffTransUnit UpdateValue(XLiffDocument xliffTarget, XLiffTransUnit tuSource,
-			string                                       newValue,    LocalizingInfo locInfo,
+		private XLiffTransUnit? UpdateValue(XLiffDocument xliffTarget, XLiffTransUnit? tuSource,
+			string?                                       newValue,    LocalizingInfo locInfo,
 			string                                       tuId)
 		{
 			// One would think there would be a source XLiffTransUnit, but that isn't necessarily true
@@ -226,8 +226,8 @@ namespace L10NSharp.XLiffUtils
 				tuTarget.AddNote("ID: " + tuId);
 			}
 
-			tuTarget.AddOrReplaceVariant(locInfo.LangId, newValue);
-			xliffTarget.File.Body.TranslationsById[tuId] = newValue;
+			tuTarget.AddOrReplaceVariant(locInfo.LangId!, newValue!);
+			xliffTarget.File.Body.TranslationsById[tuId] = newValue!;
 			_updated = true;
 			return tuTarget;
 		}

--- a/src/L10NSharp/XLiffUtils/XliffXmlSerializationHelper.cs
+++ b/src/L10NSharp/XLiffUtils/XliffXmlSerializationHelper.cs
@@ -126,7 +126,7 @@ namespace L10NSharp.XLiffUtils
 		/// <param name="filename">The filename from which to load</param>
 		/// <param name="e">The exception generated during the deserialization.</param>
 		/// ------------------------------------------------------------------------------------
-		public static T DeserializeFromFile<T>(string filename, out Exception e) where T : class
+		public static T? DeserializeFromFile<T>(string filename, out Exception? e) where T : class
 		{
 			return DeserializeFromFile<T>(filename, false, out e);
 		}
@@ -142,10 +142,10 @@ namespace L10NSharp.XLiffUtils
 		/// these elements will be ignored during a deserialization.</param>
 		/// <param name="e">The exception generated during the deserialization.</param>
 		/// ------------------------------------------------------------------------------------
-		public static T DeserializeFromFile<T>(string filename, bool fKeepWhitespaceInElements,
-			out Exception                             e) where T : class
+		public static T? DeserializeFromFile<T>(string filename, bool fKeepWhitespaceInElements,
+			out Exception?                             e) where T : class
 		{
-			T data = null;
+			T? data = null;
 			e = null;
 
 			try


### PR DESCRIPTION
After seeing some fixes from @imnasnainaec, I figured I'd try my hand at enabling NRT and fixing some issues that came up. 

There's currently 4 warnings still in place, I wasn't sure what the right call would be, so we can leave them in or come up with a fix together. They are:
```
    src\L10NSharp\XLiffUtils\XLiffBody.cs(173,22): warning CS8604: Possible null reference argument for parameter 'key' in 'string ConcurrentDictionary<string, string>.this[string key]'.
    src\L10NSharp\XLiffUtils\XLiffBody.cs(175,22): warning CS8604: Possible null reference argument for parameter 'key' in 'string ConcurrentDictionary<string, string>.this[string key]'.
    src\L10NSharp\XLiffUtils\XLiffBody.cs(201,21): warning CS8604: Possible null reference argument for parameter 'key' in 'string ConcurrentDictionary<string, string>.this[string key]'.
    src\L10NSharp\XLiffUtils\XliffLocalizationManager.cs(126,12): warning CS8618: Non-nullable property 'DefaultStringFilePath' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
```

There's a lot of code that used `XLiffTransUnit.Id` with the assumption that it's not null, however it can be, I've fixed many of those.

Some places I've added checks like `if x is null throw new exception` this is only in cases where we would have thrown anyway when accessing a property on x later down, so while this may not fix a bug, it does give much better feedback as to what was null.

There's a few places where code may have been returning null, which are now returning an empty string, these were changed due to the method already returning an empty string elsewhere, with the assumption that the method was written to never return null, and these cases were missed.

One change I did make is to constrain `ILocalizationManagerInternal<T>` T to only be a class, this may effect consumers, but I don't think that's possible as the only implementation of this internal interface is a T of `XLiffDocument`, and I think if anything else were to be used there would be a crash at runtime, so I don't think it's a problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/157)
<!-- Reviewable:end -->
