### PR TITLE
Add qps-ploc pseudolocalization support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added a repository-level MIT `LICENSE` file, which is now bundled into the NuGet packages (via `PackageLicenseFile`).
 - [L10NSharp] Added `net8.0` as a target framework, enabling use on non-Windows platforms, and added cross-platform CI/CD coverage for `net8.0`.
 - [L10NSharp] Added UiLanguageChanged event to ILocalizationManager. This provides a way for clients to deal with changes now that (in Windows) LocalizeItemDlg<XLiffDocument>.StringsLocalized no longer exists.
+- [L10NSharp] Added pseudolocalization support: any lookup for the standard `qps-ploc` pseudo-locale (`LocalizationManager.PseudoLocalizationLanguageId`) returns the English text pseudolocalized at runtime — every vowel doubled with an accent on the first of the pair, wrapped in brackets (e.g. `[Tîitlée Mîissîing]`) — so testers can spot non-internationalized strings and layout problems. No translation files exist or are created for it. Set `LocalizationManager.OfferPseudoLocalization = true` to include it in `GetAvailableLocalizedLanguages()`/`GetUILanguages()`; `LocalizationManager.PseudoLocalize(string)` exposes the transform directly. The transform is self-contained (its placeholder/markup-skipping logic was adapted from the MIT-licensed PseudoLocalizer project — see `src/L10NSharp/Pseudo/README.md`), so no new package dependency is added.
 
 ### Changed
 

--- a/src/L10NSharp.Tests/PseudoLocalizationTests.cs
+++ b/src/L10NSharp.Tests/PseudoLocalizationTests.cs
@@ -1,0 +1,395 @@
+﻿using System.IO;
+using System.Linq;
+using L10NSharp.XLiffUtils;
+using NUnit.Framework;
+
+namespace L10NSharp.Tests
+{
+	/// <summary>
+	/// Tests for the qps-ploc pseudo-locale: lookups for it return the English text
+	/// pseudolocalized (vowels doubled and accented, bracketed) at runtime.
+	/// </summary>
+	[TestFixture]
+	public class PseudoLocalizationTests
+	{
+		private const string AppId = "test";
+		private const string AppName = "unit test";
+		private const string AppVersion = "1.0.0";
+		private const string Pseudo = LocalizationManager.PseudoLocalizationLanguageId;
+
+		[SetUp]
+		public void Setup()
+		{
+			LocalizationManager.TranslationMemoryKind = TranslationMemory.XLiff;
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			LocalizationManager.OfferPseudoLocalization = false;
+			LocalizationManagerInternal<XLiffDocument>.LoadedManagers.Clear();
+			LocalizationManagerInternal<XLiffDocument>.MapToExistingLanguage.Clear();
+			LocalizationManager.SetUILanguage(LocalizationManager.kDefaultLang);
+		}
+
+		#region Transform behavior we rely on
+
+		[Test]
+		public void PseudoLocalize_PlainEnglish_VowelsDoubledWithLeadingAccentAndBracketed()
+		{
+			// Every vowel doubles (expansion), accented on the first of the pair
+			// (readable but unmistakably transformed), and the string is bracketed.
+			Assert.That(LocalizationManager.PseudoLocalize("Cook Book"),
+				Is.EqualTo("[Cöoöok Böoöok]")); // [Cöoöok Böoöok]
+			Assert.That(LocalizationManager.PseudoLocalize("Edit"),
+				Is.EqualTo("[ÉEdîit]")); // [ÉEdîit]
+		}
+
+		[Test]
+		public void PseudoLocalize_NoVowels_StillBracketed()
+		{
+			// An all-consonant string gets no accents or expansion, but the brackets
+			// still mark it as having gone through localization.
+			Assert.That(LocalizationManager.PseudoLocalize("PDF"), Is.EqualTo("[PDF]"));
+		}
+
+		[Test]
+		public void PseudoLocalize_IsDeterministic()
+		{
+			const string english = "The quick brown fox jumps over the lazy dog";
+			Assert.That(LocalizationManager.PseudoLocalize(english),
+				Is.EqualTo(LocalizationManager.PseudoLocalize(english)));
+		}
+
+		[TestCase("Page {0} of {1}", "{0}", "{1}")]
+		[TestCase("Showing {0:n0} items", "{0:n0}")]
+		[TestCase("Save %0 of %1 pages", "%0", "%1")]
+		[TestCase("Installed {app_title} at {installFolder}", "{app_title}", "{installFolder}")]
+		[TestCase("Level {N}", "{N}")]
+		public void PseudoLocalize_FormatPlaceholders_SurviveUntouched(string english,
+			params string[] placeholders)
+		{
+			var result = LocalizationManager.PseudoLocalize(english);
+			foreach (var placeholder in placeholders)
+				Assert.That(result, Does.Contain(placeholder));
+		}
+
+		[TestCase("<strong>Bold</strong> text", "<strong>", "</strong>")]
+		[TestCase("A <a href=\"x\">link</a>.", "<a href=\"x\">", "</a>")]
+		public void PseudoLocalize_HtmlTags_SurviveUntouched(string english,
+			params string[] tags)
+		{
+			var result = LocalizationManager.PseudoLocalize(english);
+			foreach (var tag in tags)
+				Assert.That(result, Does.Contain(tag));
+		}
+
+		[TestCase(null)]
+		[TestCase("")]
+		public void PseudoLocalize_NullOrEmpty_ReturnedAsIs(string english)
+		{
+			Assert.That(LocalizationManager.PseudoLocalize(english), Is.EqualTo(english));
+		}
+
+		#endregion
+
+		#region Manager-level behavior
+
+		[Test]
+		public void GetString_UILanguageIsPseudo_ReturnsPseudolocalizedEnglishText()
+		{
+			using (var folder = new TempFolder())
+			{
+				SetupManager(folder, Pseudo);
+				Assert.That(LocalizationManager.GetString("blahId", "blah"),
+					Is.EqualTo(LocalizationManager.PseudoLocalize("blah")));
+			}
+		}
+
+		[Test]
+		public void GetString_UILanguageIsPseudo_StringMissingEverywhere_PseudolocalizesSuppliedEnglish()
+		{
+			using (var folder = new TempFolder())
+			{
+				SetupManager(folder, Pseudo);
+				Assert.That(LocalizationManager.GetString("no.such.id", "only in code"),
+					Is.EqualTo(LocalizationManager.PseudoLocalize("only in code")));
+			}
+		}
+
+		[Test]
+		public void GetString_UILanguageIsRealLanguage_NeverGetsPseudoText()
+		{
+			using (var folder = new TempFolder())
+			{
+				SetupManager(folder, "fr");
+				Assert.That(LocalizationManager.GetString("blahId", "blah"),
+					Is.EqualTo("blahInFrench"));
+			}
+		}
+
+		[Test]
+		public void GetDynamicStringOrEnglish_PseudoLangId_PseudolocalizesSuppliedEnglish()
+		{
+			using (var folder = new TempFolder())
+			{
+				SetupManager(folder);
+				Assert.That(
+					LocalizationManager.GetDynamicStringOrEnglish(AppId, "blahId", "from the code",
+						null, Pseudo),
+					Is.EqualTo(LocalizationManager.PseudoLocalize("from the code")),
+					"the code-supplied English should win over the cache, as for 'en'");
+			}
+		}
+
+		[Test]
+		public void GetDynamicStringOrEnglish_PseudoLangIdNoDefault_PseudolocalizesCachedEnglish()
+		{
+			using (var folder = new TempFolder())
+			{
+				SetupManager(folder);
+				Assert.That(
+					LocalizationManager.GetDynamicStringOrEnglish(AppId, "blahId", null, null,
+						Pseudo),
+					Is.EqualTo(LocalizationManager.PseudoLocalize("blah")));
+			}
+		}
+
+		[Test]
+		public void GetDynamicString_UILanguageIsPseudo_DoesNotCreatePseudoTranslationFile()
+		{
+			using (var folder = new TempFolder())
+			{
+				SetupManager(folder, Pseudo);
+				LocalizationManager.GetDynamicString(AppId, "brand.new.id", "novel string");
+				var pseudoFiles = Directory
+					.GetFiles(folder.Path, "*", SearchOption.AllDirectories)
+					.Where(f => f.IndexOf(Pseudo, System.StringComparison.OrdinalIgnoreCase) >= 0);
+				Assert.That(pseudoFiles, Is.Empty);
+			}
+		}
+
+		[TestCase(Pseudo, null, Description = "pseudo alone")]
+		[TestCase(Pseudo, "fr", Description = "pseudo preferred over French")]
+		public void GetString_PreferredLanguagesStartingWithPseudo_ReturnsPseudolocalizedEnglish(
+			string firstLangId, string secondLangId)
+		{
+			var preferredLangIds = secondLangId == null
+				? new[] { firstLangId }
+				: new[] { firstLangId, secondLangId };
+			using (var folder = new TempFolder())
+			{
+				SetupManager(folder);
+				var result = LocalizationManager.GetString("blahId", "blah", null,
+					preferredLangIds, out var languageIdUsed);
+				Assert.That(result, Is.EqualTo(LocalizationManager.PseudoLocalize("blah")));
+				Assert.That(languageIdUsed, Is.EqualTo(Pseudo));
+			}
+		}
+
+		[Test]
+		public void GetString_LanguageWithTranslationPreferredOverPseudo_ReturnsTranslation()
+		{
+			using (var folder = new TempFolder())
+			{
+				SetupManager(folder);
+				var result = LocalizationManager.GetString("blahId", "blah", null,
+					new[] { "fr", Pseudo }, out var languageIdUsed);
+				Assert.That(result, Is.EqualTo("blahInFrench"));
+				Assert.That(languageIdUsed, Is.EqualTo("fr"));
+			}
+		}
+
+		[Test]
+		public void GetString_EnglishPreferredOverPseudo_ReturnsPlainEnglish()
+		{
+			using (var folder = new TempFolder())
+			{
+				SetupManager(folder);
+				var result = LocalizationManager.GetString("blahId", "blah", null,
+					new[] { "en", Pseudo }, out var languageIdUsed);
+				Assert.That(result, Is.EqualTo("blah"));
+				Assert.That(languageIdUsed, Is.EqualTo("en"));
+			}
+		}
+
+		[Test]
+		public void GetString_EnglishPreferredOverPseudo_StringMissingFromCache_StillReturnsPlainEnglish()
+		{
+			using (var folder = new TempFolder())
+			{
+				SetupManager(folder);
+				// The id is in no cache at all, but English (always satisfiable from the
+				// code-supplied text) was preferred over the pseudo-locale, so it must win.
+				var result = LocalizationManager.GetString("no.such.id", "only in code", null,
+					new[] { "en", Pseudo }, out var languageIdUsed);
+				Assert.That(result, Is.EqualTo("only in code"));
+				Assert.That(languageIdUsed, Is.EqualTo("en"));
+			}
+		}
+
+		[Test]
+		public void GetString_NullEntryInPreferredLanguagesBeforePseudo_DoesNotThrow()
+		{
+			using (var folder = new TempFolder())
+			{
+				SetupManager(folder);
+				var result = LocalizationManager.GetString("blahId", "blah", null,
+					new[] { null, Pseudo }, out var languageIdUsed);
+				Assert.That(result, Is.EqualTo(LocalizationManager.PseudoLocalize("blah")));
+				Assert.That(languageIdUsed, Is.EqualTo(Pseudo));
+			}
+		}
+
+		[Test]
+		public void GetIsStringAvailableForLangId_Pseudo_ReportsSameAsEnglish()
+		{
+			using (var folder = new TempFolder())
+			{
+				SetupManager(folder);
+				Assert.That(LocalizationManager.GetIsStringAvailableForLangId("blahId", Pseudo),
+					Is.True);
+				Assert.That(LocalizationManager.GetIsStringAvailableForLangId("no.such.id", Pseudo),
+					Is.False);
+			}
+		}
+
+		[Test]
+		public void GetAvailableLocalizedLanguages_RespectsOfferPseudoLocalization()
+		{
+			using (var folder = new TempFolder())
+			{
+				SetupManager(folder);
+				Assert.That(LocalizationManager.GetAvailableLocalizedLanguages(),
+					Does.Not.Contain(Pseudo), "pseudo-locale should not be advertised by default");
+
+				LocalizationManager.OfferPseudoLocalization = true;
+				Assert.That(LocalizationManager.GetAvailableLocalizedLanguages(),
+					Does.Contain(Pseudo));
+			}
+		}
+
+		[Test]
+		public void StringCountAndFractions_Pseudo_ReportEnglishCompleteness()
+		{
+			using (var folder = new TempFolder())
+			{
+				SetupManager(folder);
+				Assert.That(LocalizationManager.StringCount(Pseudo),
+					Is.EqualTo(LocalizationManager.StringCount(LocalizationManager.kDefaultLang)));
+				Assert.That(LocalizationManager.FractionApproved(Pseudo), Is.EqualTo(1.0f));
+				Assert.That(LocalizationManager.FractionTranslated(Pseudo), Is.EqualTo(1.0f));
+			}
+		}
+
+		[Test]
+		public void GetUILanguages_PseudoOffered_HasHardCodedDisplayName()
+		{
+			using (var folder = new TempFolder())
+			{
+				SetupManager(folder);
+				LocalizationManager.OfferPseudoLocalization = true;
+				var pseudoCulture = LocalizationManager.GetUILanguages(true)
+					.FirstOrDefault(c => c.Name == Pseudo);
+				Assert.That(pseudoCulture, Is.Not.Null);
+				Assert.That(pseudoCulture.DisplayName, Is.EqualTo("Pseudo-English (qps-ploc)"));
+				Assert.That(pseudoCulture.NativeName, Is.EqualTo("Pseudo-English (qps-ploc)"));
+			}
+		}
+
+		/// <summary>
+		/// The WinForms component localizers -- what sets the Text of controls, tool strip items
+		/// and column headers created in the designer -- read the string cache directly rather
+		/// than going through GetLocalizedString. There is no cache for the pseudo-locale, so
+		/// without a hook here they found nothing and left the designer's plain English in place,
+		/// which under this locale means "never internationalized" and so was actively
+		/// misleading. See BL-16748.
+		/// </summary>
+		[Test]
+		public void GetStringFromStringCache_Pseudo_PseudolocalizesTheCachedEnglish()
+		{
+			using (var folder = new TempFolder())
+			{
+				SetupManager(folder, Pseudo);
+				var lm = LocalizationManagerInternal<XLiffDocument>.LoadedManagers[AppId];
+
+				// Sanity check: the English is there to be derived from.
+				Assert.That(lm.GetStringFromStringCache(LocalizationManager.kDefaultLang, "blahId"),
+					Is.EqualTo("blah"));
+
+				Assert.That(lm.GetStringFromStringCache(Pseudo, "blahId"),
+					Is.EqualTo(LocalizationManager.PseudoLocalize("blah")));
+			}
+		}
+
+		[Test]
+		public void GetStringFromStringCache_PseudoAndIdNotInEnglish_ReturnsNullSoTheCallerKeepsItsOwnText()
+		{
+			using (var folder = new TempFolder())
+			{
+				SetupManager(folder, Pseudo);
+				var lm = LocalizationManagerInternal<XLiffDocument>.LoadedManagers[AppId];
+				Assert.That(lm.GetStringFromStringCache(Pseudo, "no.such.id"), Is.Null);
+			}
+		}
+
+		[Test]
+		public void SetUILanguage_Pseudo_DoesNotThrow()
+		{
+			Assert.DoesNotThrow(() => LocalizationManager.SetUILanguage(Pseudo));
+			Assert.That(LocalizationManager.UILanguageId, Is.EqualTo(Pseudo));
+		}
+
+		#endregion
+
+		/// <summary>
+		/// Installs English (blahId="blah", theId="from English Translation") and French
+		/// (blahId="blahInFrench") translations, sets the UI language, and loads a manager.
+		/// </summary>
+		private static void SetupManager(TempFolder folder,
+			string uiLanguageId = LocalizationManager.kDefaultLang)
+		{
+			LocalizationManagerInternal<XLiffDocument>.LoadedManagers.Clear();
+
+			var englishDoc = CreateDocument(AppVersion, "en");
+			englishDoc.AddTransUnit(CreateTransUnit("theId", "en", "from English Translation"));
+			englishDoc.AddTransUnit(CreateTransUnit("blahId", "en", "blah"));
+			englishDoc.Save(Path.Combine(folder.Path,
+				LocalizationManager.GetTranslationFileNameForLanguage(AppId, "en")));
+
+			var frenchDoc = CreateDocument(null, "en", "fr");
+			var frenchTu = CreateTransUnit("blahId", "en", "blah");
+			frenchTu.Target = new XLiffTransUnitVariant { Lang = "fr", Value = "blahInFrench" };
+			frenchTu.TranslationStatus = TranslationStatus.Approved;
+			frenchDoc.AddTransUnit(frenchTu);
+			frenchDoc.Save(Path.Combine(folder.Path,
+				LocalizationManager.GetTranslationFileNameForLanguage(AppId, "fr")));
+
+			LocalizationManager.SetUILanguage(uiLanguageId);
+			var manager = new XliffLocalizationManager(AppId, null, AppName, AppVersion,
+				folder.Path, folder.Combine("generated"), folder.Combine("userModified"), null);
+			LocalizationManagerInternal<XLiffDocument>.LoadedManagers[AppId] = manager;
+		}
+
+		private static XLiffDocument CreateDocument(string productVersion, string sourceLang,
+			string targetLang = null)
+		{
+			var doc = new XLiffDocument { File = { SourceLang = sourceLang } };
+			if (!string.IsNullOrEmpty(productVersion))
+				doc.File.ProductVersion = productVersion;
+			if (!string.IsNullOrEmpty(targetLang))
+				doc.File.TargetLang = targetLang;
+			doc.File.Original = "test.dll";
+			return doc;
+		}
+
+		private static XLiffTransUnit CreateTransUnit(string id, string lang, string value)
+		{
+			return new XLiffTransUnit
+			{
+				Id = id,
+				Source = new XLiffTransUnitVariant { Lang = lang, Value = value }
+			};
+		}
+	}
+}

--- a/src/L10NSharp/L10NCultureInfo.cs
+++ b/src/L10NSharp/L10NCultureInfo.cs
@@ -104,6 +104,16 @@ namespace L10NSharp
 				else if (name == "id")
 					NativeName = "Bahasa Indonesia";
 			}
+
+			if (LocalizationManager.IsPseudoLanguageId(name))
+			{
+				// Don't rely on the OS to produce a sensible name (or canonical casing) for the
+				// pseudo-locale (and Linux typically doesn't know the culture at all).
+				Name = LocalizationManager.PseudoLocalizationLanguageId;
+				EnglishName = "Pseudo-English (qps-ploc)";
+				DisplayName = EnglishName;
+				NativeName = EnglishName;
+			}
 		}
 
 		private L10NCultureInfo(CultureInfo ci)

--- a/src/L10NSharp/LocalizationManager.cs
+++ b/src/L10NSharp/LocalizationManager.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Reflection;
 using System.Threading;
 using JetBrains.Annotations;
+using L10NSharp.Pseudo;
 using L10NSharp.TMXUtils;
 using L10NSharp.XLiffUtils;
 
@@ -14,6 +15,14 @@ namespace L10NSharp
 	public static class LocalizationManager
 	{
 		public const string kDefaultLang = "en";
+
+		/// <summary>
+		/// The standard pseudo-locale tag. Any lookup for this language returns the English
+		/// text pseudolocalized (vowels doubled and accented, bracketed) at runtime; no translation files
+		/// exist or are created for it.
+		/// </summary>
+		public const string PseudoLocalizationLanguageId = "qps-ploc";
+
 		internal const string kL10NPrefix = "_L10N_:";
 		internal const string kAppVersionPropTag = "x-appversion";
 
@@ -40,6 +49,25 @@ namespace L10NSharp
 		/// translation didn't exist.
 		/// </summary>
 		public static bool ReturnOnlyApprovedStrings;
+
+		/// <summary>
+		/// When true, the qps-ploc pseudo-locale is included in GetAvailableLocalizedLanguages()
+		/// (and hence in the language lists shown to users). Lookups for qps-ploc work
+		/// regardless of this setting; it only controls whether the pseudo-locale is advertised.
+		/// Default: false.
+		/// </summary>
+		public static bool OfferPseudoLocalization { get; set; }
+
+		/// <summary>
+		/// Applies the same pseudolocalization transform used for qps-ploc lookups to the given
+		/// English text. Exposed so applications can pseudolocalize strings that take paths
+		/// around L10NSharp.
+		/// </summary>
+		[PublicAPI]
+		public static string PseudoLocalize(string english) => PseudoLocalization.Transform(english);
+
+		internal static bool IsPseudoLanguageId(string langId) =>
+			string.Equals(langId, PseudoLocalizationLanguageId, StringComparison.OrdinalIgnoreCase);
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>

--- a/src/L10NSharp/LocalizationManagerInternal.cs
+++ b/src/L10NSharp/LocalizationManagerInternal.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using L10NSharp.Pseudo;
 using L10NSharp.XLiffUtils;
 // ReSharper disable StaticMemberInGenericType - these static fields are parameter-independent
 
@@ -261,6 +262,10 @@ namespace L10NSharp
 			var langsHavingLocalizations = (LoadedManagers == null ? new List<string>() :
 				LoadedManagers.Values.SelectMany(lm => lm.GetAvailableUILanguageTags())
 					.Distinct().ToList());
+			// The pseudo-locale is derived from the English strings at lookup time, so it is
+			// available whenever anything is, but is only advertised when the app opts in.
+			if (LocalizationManager.OfferPseudoLocalization && langsHavingLocalizations.Count > 0)
+				langsHavingLocalizations.Add(LocalizationManager.PseudoLocalizationLanguageId);
 			return langsHavingLocalizations;
 		}
 
@@ -268,6 +273,9 @@ namespace L10NSharp
 		{
 			if (LoadedManagers == null)
 				return false;
+			// The pseudo-locale is exactly as available as English.
+			if (LocalizationManager.IsPseudoLanguageId(langId))
+				langId = LocalizationManager.kDefaultLang;
 			return LoadedManagers.Values.Any(m => m.IsUILanguageAvailable(langId));
 		}
 
@@ -346,6 +354,8 @@ namespace L10NSharp
 		/// </summary>
 		public static int NumberApproved(string lang)
 		{
+			if (LocalizationManager.IsPseudoLanguageId(lang))
+				lang = LocalizationManager.kDefaultLang; // pseudo is exactly as complete as English
 			if (lang == LocalizationManager.kDefaultLang)
 				return StringCount(lang);
 			var approved = 0;
@@ -377,6 +387,8 @@ namespace L10NSharp
 		/// </summary>
 		public static int NumberTranslated(string lang)
 		{
+			if (LocalizationManager.IsPseudoLanguageId(lang))
+				lang = LocalizationManager.kDefaultLang; // pseudo is exactly as complete as English
 			if (lang == LocalizationManager.kDefaultLang)
 				return StringCount(lang);
 			var translated = 0;
@@ -408,6 +420,8 @@ namespace L10NSharp
 		/// </summary>
 		public static int StringCount(string lang)
 		{
+			if (LocalizationManager.IsPseudoLanguageId(lang))
+				lang = LocalizationManager.kDefaultLang; // pseudo is exactly as complete as English
 			var count = 0;
 			foreach (var lm in s_loadedManagers.Values)
 			{
@@ -516,6 +530,16 @@ namespace L10NSharp
 					$"Initialized LMs are {string.Join(", ", LoadedManagers.Keys)}");
 			}
 
+			// For the pseudo-locale, pseudolocalize the English text. As for English, the
+			// caller-supplied englishText wins over the cache. Note that this never engages the
+			// dynamic-string collection machinery below: no files exist or are written for the
+			// pseudo-locale.
+			if (LocalizationManager.IsPseudoLanguageId(langId))
+			{
+				return PseudoLocalization.Transform(englishText ??
+					lm.GetStringFromStringCache(LocalizationManager.kDefaultLang, id));
+			}
+
 			// If they asked for English, we are going to use the supplied englishText, regardless
 			// of what may be cached, following the rule that the current c# code always wins. In
 			// case we really need to recover the cached version, we will retrieve that only if no
@@ -566,6 +590,10 @@ namespace L10NSharp
 		{
 			if (string.IsNullOrEmpty(langId))
 				return null;
+			// The pseudo-locale never maps to or from a real language, and no localization
+			// files exist for it, so don't try to load any.
+			if (LocalizationManager.IsPseudoLanguageId(langId))
+				return langId;
 			// It's a concurrent dictionary, so we can (for performance) try this without a lock.
 			if (MapToExistingLanguage.TryGetValue(langId, out var realId))
 				return realId;
@@ -612,6 +640,10 @@ namespace L10NSharp
 
 			if (string.IsNullOrEmpty(langId) || string.IsNullOrEmpty(id))
 				return false;
+
+			// Every English string is by definition available in the pseudo-locale.
+			if (LocalizationManager.IsPseudoLanguageId(langId))
+				langId = LocalizationManager.kDefaultLang;
 
 			var str = MapToExistingLanguageOrAddMapping(id, langId, out _);
 			return !string.IsNullOrEmpty(str);
@@ -710,6 +742,14 @@ namespace L10NSharp
 		{
 			if (string.IsNullOrWhiteSpace(stringId))
 				return LocalizationManager.StripOffLocalizationInfoFromText(englishText);
+			// For the pseudo-locale, pseudolocalize the English text (as for English, the
+			// caller-supplied englishText wins over the cache).
+			if (LocalizationManager.IsPseudoLanguageId(LocalizationManager.UILanguageId))
+			{
+				return PseudoLocalization.Transform(
+					LocalizationManager.StripOffLocalizationInfoFromText(englishText) ??
+					MapToExistingLanguageOrAddMapping(stringId, LocalizationManager.kDefaultLang, out _));
+			}
 			return GetStringFromAnyLocalizationManager(stringId) ??
 				LocalizationManager.StripOffLocalizationInfoFromText(englishText);
 		}
@@ -741,12 +781,31 @@ namespace L10NSharp
 			if (string.IsNullOrEmpty(englishText))
 				throw new ArgumentException($"{nameof(englishText)} may not be empty (because common... that can't be what you meant to do...");
 
+			// If the pseudo-locale is in the list, it always has every string (derived from the
+			// English), so only languages preferred over it can win; anything after it is moot.
+			// English is also always available (the code-supplied englishText), so note whether
+			// it too was preferred over the pseudo-locale.
+			var pseudoIndex = langIds.FindIndex(LocalizationManager.IsPseudoLanguageId);
+			var englishPreferredOverPseudo = pseudoIndex >= 0 && langIds.Take(pseudoIndex)
+				.Any(l => l == "en" ||
+					(l != null && l.StartsWith("en-", StringComparison.OrdinalIgnoreCase)));
+			if (pseudoIndex >= 0)
+				langIds = langIds.Take(pseudoIndex).ToList();
+
 			var stringFromAnyLocalizationManager = GetStringFromAnyLocalizationManager(stringId, langIds, out languageIdUsed);
 
 			// Even if found in the English l10n file, we prefer to use the version that came from
 			// the code.
 			if (languageIdUsed == "en" || string.IsNullOrEmpty(stringFromAnyLocalizationManager))
 			{
+				// No language preferred over the pseudo-locale had the string (and English was
+				// not preferred over it), so pseudolocalize the code-supplied English.
+				if (pseudoIndex >= 0 && !englishPreferredOverPseudo)
+				{
+					languageIdUsed = LocalizationManager.PseudoLocalizationLanguageId;
+					return PseudoLocalization.Transform(
+						LocalizationManager.StripOffLocalizationInfoFromText(englishText));
+				}
 				languageIdUsed = "en";
 				return LocalizationManager.StripOffLocalizationInfoFromText(englishText);
 			}

--- a/src/L10NSharp/Pseudo/EscapeHelpers.cs
+++ b/src/L10NSharp/Pseudo/EscapeHelpers.cs
@@ -1,0 +1,76 @@
+// Adapted from the MIT-licensed PseudoLocalizer project, Copyright (C) 2012, Anders Kaplan.
+// See README.md in this folder for provenance, license, and local changes.
+
+namespace L10NSharp.Pseudo
+{
+	internal static class EscapeHelpers
+	{
+		// Local addition (not upstream): placeholder names may be alphanumeric/underscore,
+		// not just digits — consumers substitute named placeholders like "{app_title}".
+		private static bool IsPlaceholderNameChar(char c)
+			=> char.IsLetterOrDigit(c) || c == '_';
+
+		internal static bool ShouldTransform(char[] array, char ch, ref int i)
+		{
+			// Are we at the start of a potential placeholder (e.g. "{?...}")
+			if (ch == '{' && i < array.Length - 2)
+			{
+				int j = i;
+
+				while (j < array.Length - 1 && IsPlaceholderNameChar(array[++j]))
+				{
+					// Consume the placeholder name (digits for "{0}", or a name like "{lang}")
+				}
+
+				if (array[j] == ':')
+				{
+					while (j < array.Length - 1 && array[++j] != '}')
+					{
+						// Consume all of any format specifier (e.g. "{0:yyyy}" for a DateTime)
+					}
+				}
+
+				if (array[j] == '}')
+				{
+					i = j;
+					return false;
+				}
+			}
+			else if (ch == '%' && i < array.Length - 1 && char.IsDigit(array[i + 1]))
+			{
+				// Local addition (not upstream): "%0"-style placeholders, substituted by
+				// consumers' front ends (e.g. Bloom's simpleFormat), pass through untouched.
+				int j = i;
+
+				while (j < array.Length - 1 && char.IsDigit(array[j + 1]))
+					j++;
+
+				i = j;
+				return false;
+			}
+			else if (ch == '<' && i < array.Length - 2)
+			{
+				// Are we at the start of a potential HTML tag (e.g. "<a/>")
+				int j = i;
+
+				char next = array[i + 1];
+
+				if ((next >= 'a' && next <= 'z') || (next >= 'A' && next <= 'Z') || next == '/')
+				{
+					while (j < array.Length - 1 && array[++j] != '>')
+					{
+						// Consume all of the tag
+					}
+
+					if (array[j] == '>')
+					{
+						i = j;
+						return false;
+					}
+				}
+			}
+
+			return true;
+		}
+	}
+}

--- a/src/L10NSharp/Pseudo/PseudoLocalization.cs
+++ b/src/L10NSharp/Pseudo/PseudoLocalization.cs
@@ -1,0 +1,20 @@
+namespace L10NSharp.Pseudo
+{
+	/// <summary>
+	/// Produces the pseudolocalized ("qps-ploc") form of English strings: every vowel is
+	/// doubled (accented on the first of the pair) for ~30-40% expansion, and the whole
+	/// string is bracketed, with format placeholders and HTML/XML markup passed through
+	/// untouched. E.g. "Title Missing" becomes "[Tîitlée Mîissîing]". The transform is
+	/// deterministic, and self-contained in this folder (see its README.md), so L10NSharp
+	/// carries no extra dependency for this feature.
+	/// </summary>
+	internal static class PseudoLocalization
+	{
+		public static string Transform(string english)
+		{
+			if (string.IsNullOrEmpty(english))
+				return english;
+			return "[" + VowelStretch.Transform(english) + "]";
+		}
+	}
+}

--- a/src/L10NSharp/Pseudo/README.md
+++ b/src/L10NSharp/Pseudo/README.md
@@ -1,0 +1,61 @@
+# Pseudolocalization transform
+
+Everything in this folder is `internal`, in the `L10NSharp.Pseudo` namespace; the only way
+in is `PseudoLocalization.Transform` (exposed publicly as `LocalizationManager.PseudoLocalize`).
+
+## The transform
+
+`[Tîitlée Mîissîing]` for "Title Missing":
+
+- **Every vowel is doubled, accented on the first of the pair** (`VowelStretch`). The
+  doubling provides the ~30–40% expansion (inside the words, where it stresses layout the
+  way real translations do), and the accented-plain pairs (`îi`, `öo`, `ée`) make the text
+  unmistakably transformed while staying easy to read — no real language systematically
+  produces that pattern. Consonants, digits, and punctuation are untouched.
+- **The whole string is bracketed.** A missing `]` reveals truncation; brackets mid-sentence
+  reveal runtime string concatenation.
+- **Placeholders and markup pass through untouched** (`EscapeHelpers`): `{0}`/`{0:fmt}`
+  format placeholders, named `{app_title}`-style and `%0`-style placeholders (both
+  substituted by consumers' front ends, e.g. Bloom's), and HTML/XML tags.
+
+The transform is deterministic, so screenshots are comparable across runs. The behaviors
+consumers rely on are pinned by `PseudoLocalizationTests`.
+
+Design notes: the doubled-vowel expansion follows Mozilla's pseudolocalization approach
+(Fluent's "accented" locale); brackets are common to Microsoft's qps-ploc, Android's en-XA,
+and others. Earlier iterations of this feature (see git history) used the full accent map
+and per-word padding of the PseudoLocalizer project, which we used as a starting point but
+replaced for readability.
+
+## Provenance
+
+`EscapeHelpers` (the placeholder/markup-skipping logic) is adapted from the MIT-licensed
+[PseudoLocalizer](https://github.com/martincostello/Pseudolocalizer) project, Copyright (C)
+2012, Anders Kaplan, and extended here to also recognize `%0`-style and named
+`{app_title}`-style placeholders. The rest of the folder is original to L10NSharp.
+
+Upstream license for the adapted code:
+
+```
+The MIT License (MIT)
+
+Copyright (C) 2012, Anders Kaplan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```

--- a/src/L10NSharp/Pseudo/VowelStretch.cs
+++ b/src/L10NSharp/Pseudo/VowelStretch.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace L10NSharp.Pseudo
+{
+	/// <summary>
+	/// Doubles every vowel, accenting the first of each pair, and leaves consonants,
+	/// digits, and punctuation untouched: "Title Missing" becomes "Tîitlée Mîissîing".
+	/// This keeps the pseudo text easy to read while still being unmistakably transformed
+	/// (no real language systematically produces the accented-plain vowel pairs), and it
+	/// provides the ~30-40% expansion inside the words themselves, with no filler
+	/// characters. Format placeholders and HTML/XML tags pass through untouched
+	/// (via EscapeHelpers).
+	/// </summary>
+	internal static class VowelStretch
+	{
+		private static readonly Dictionary<char, char> AccentedVowels = new Dictionary<char, char>
+		{
+			{ 'a', 'å' },
+			{ 'e', 'é' },
+			{ 'i', 'î' },
+			{ 'o', 'ö' },
+			{ 'u', 'û' },
+			{ 'A', 'Å' },
+			{ 'E', 'É' },
+			{ 'I', 'Î' },
+			{ 'O', 'Ö' },
+			{ 'U', 'Û' },
+		};
+
+		public static string Transform(string value)
+		{
+			var array = value.ToCharArray();
+			var builder = new StringBuilder(value.Length * 2);
+
+			for (int i = 0; i < array.Length; i++)
+			{
+				char ch = array[i];
+				int indexBefore = i;
+
+				if (EscapeHelpers.ShouldTransform(array, ch, ref i))
+				{
+					if (AccentedVowels.TryGetValue(ch, out var accented))
+					{
+						// Each vowel doubles for expansion, accented on the first of the
+						// pair so the text stays easy to read.
+						builder.Append(accented);
+						builder.Append(ch);
+					}
+					else
+					{
+						builder.Append(ch);
+					}
+				}
+				else
+				{
+					// Skipped span (placeholder or markup): copy it through untouched.
+					for (int j = indexBefore; j < i + 1; j++)
+						builder.Append(array[j]);
+				}
+			}
+
+			return builder.ToString();
+		}
+	}
+}

--- a/src/L10NSharp/XLiffUtils/XliffLocalizationManager.cs
+++ b/src/L10NSharp/XLiffUtils/XliffLocalizationManager.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
+using L10NSharp.Pseudo;
 
 namespace L10NSharp.XLiffUtils
 {
@@ -489,6 +490,15 @@ namespace L10NSharp.XLiffUtils
 		/// ------------------------------------------------------------------------------------
 		public string GetLocalizedString(string id, string defaultText)
 		{
+			// For the pseudo-locale, pseudolocalize the English text (the code-supplied default
+			// wins over the cache, as for English).
+			if (LocalizationManager.IsPseudoLanguageId(UILanguageId))
+			{
+				return PseudoLocalization.Transform(
+					LocalizationManager.StripOffLocalizationInfoFromText(defaultText) ??
+					GetStringFromStringCache(LocalizationManager.kDefaultLang, id));
+			}
+
 			var text = (UILanguageId != LocalizationManager.kDefaultLang ? GetStringFromStringCache(UILanguageId, id) : null);
 
 			return text ?? LocalizationManager.StripOffLocalizationInfoFromText(defaultText);
@@ -497,6 +507,17 @@ namespace L10NSharp.XLiffUtils
 		/// ------------------------------------------------------------------------------------
 		public string GetStringFromStringCache(string uiLangId, string id)
 		{
+			// There is no cache for the pseudo-locale (no files exist for it), so derive it from
+			// the English entry. Doing it here rather than only in GetLocalizedString matters
+			// because the WinForms component localizers (which set the Text of designer-created
+			// controls, tool strip items and column headers) call straight into the string cache;
+			// without this they would find nothing and leave the designer's plain English in
+			// place, which is exactly what the pseudo-locale is supposed to mean "not
+			// internationalized".
+			if (LocalizationManager.IsPseudoLanguageId(uiLangId))
+				return PseudoLocalization.Transform(
+					GetStringFromStringCache(LocalizationManager.kDefaultLang, id));
+
 			var realLangId = LocalizationManagerInternal<XLiffDocument>.MapToExistingLanguageIfPossible(uiLangId);
 			return StringCache.GetString(realLangId, id);
 		}
@@ -504,6 +525,12 @@ namespace L10NSharp.XLiffUtils
 		/// ------------------------------------------------------------------------------------
 		protected string GetTooltipFromStringCache(string uiLangId, string id)
 		{
+			// See GetStringFromStringCache: same story for the tooltips of designer-created
+			// controls.
+			if (LocalizationManager.IsPseudoLanguageId(uiLangId))
+				return PseudoLocalization.Transform(
+					GetTooltipFromStringCache(LocalizationManager.kDefaultLang, id));
+
 			var realLangId = LocalizationManagerInternal<XLiffDocument>.MapToExistingLanguageIfPossible(uiLangId);
 			return StringCache.GetToolTipText(realLangId, id);
 		}


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
## Problem

Applications built on L10NSharp have no good way for testers to verify internationalization. Hard-coded (non-localizable) strings, clipped layouts, broken format placeholders, and runtime string concatenation are invisible in an English UI and only surface after real translations arrive.

## Fix

This PR adds the industry-standard **qps-ploc pseudo-locale**. Any lookup for language `qps-ploc` returns the live English text pseudolocalized — every vowel doubled with an accent on the first of the pair for ~30-40% in-word expansion, all wrapped in brackets (e.g. `Title Missing` → `[Tîitlée Mîissîing]`) — with format placeholders (`{0}`, `{0:n0}`, named `{app_title}`-style, and `%0`-style) and HTML/XML tags passed through untouched. Plain English on screen then means a hard-coded string; a missing `]` means truncation; brackets mid-sentence mean concatenation.

- Lookups work by simply setting the language code (`SetUILanguage("qps-ploc")` or a per-call language list); all the lookup funnels (static, preferred-languages, dynamic, and the WinForms paths — both runtime lookups and designer-created controls, whose localizers read the string cache directly) are hooked, and the transform is applied exactly once. The code-supplied English wins over the cache, mirroring the existing `en` rule.
- The pseudo-locale is derived from English at lookup time: no translation files exist, are loaded, or are written for it, it never maps to/from a real language, and it reports itself exactly as complete as English (availability and counts).
- `LocalizationManager.OfferPseudoLocalization` (default false) gates only whether it is *advertised* in `GetAvailableLocalizedLanguages()`/`GetUILanguages()`, so end users never see the test locale unless the app opts in (e.g. alpha channels). Display name is hard-coded as "Pseudo-English (qps-ploc)".
- The transform lives in an isolated, internal `src/L10NSharp/Pseudo/` silo and adds **no package dependency**. The vowel-doubling style follows Mozilla’s pseudolocalization approach, chosen for readability after trying several styles live in Bloom; the MIT-licensed [PseudoLocalizer](https://github.com/martincostello/Pseudolocalizer) project was the starting point, and its adapted placeholder/markup-skipping logic remains (attribution in the silo’s README). `LocalizationManager.PseudoLocalize(string)` exposes the transform for strings that bypass L10NSharp.

Additive only — no behavior change for consumers that never request qps-ploc. 31 new tests pin the transform behaviors and the lookup/gating semantics.
<!-- preflight-narrative:end -->

---
[Devin review](https://app.devin.ai/review/sillsdev/l10nsharp/pull/158)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/158)
<!-- Reviewable:end -->
