### PR TITLE
Add agent notes documenting the +semver commit-message convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Agent notes for L10nSharp
+
+## Versioning
+
+This repo versions with GitVersion, following [SemVer](https://semver.org/). Patch is the
+default increment and needs no marker. A commit that adds a backward-compatible feature
+must include `+semver:minor` in its commit message, and a breaking change `+semver:major`
+(no space after the colon; anywhere in the message). When squashing a branch, make sure
+the surviving commit keeps the marker.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
AGENTS.md (imported by CLAUDE.md) explains that GitVersion takes its version increment from `+semver:major/minor/patch` prefixes on commit subjects, and how to choose the level. Docs only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/l10nsharp/159)
<!-- Reviewable:end -->
